### PR TITLE
fix: fixed #4 ,The mcpPrompt parameter cannot be mounted

### DIFF
--- a/mcp-annotations/src/main/java/com/logaritex/mcp/method/prompt/AbstractMcpPromptMethodCallback.java
+++ b/mcp-annotations/src/main/java/com/logaritex/mcp/method/prompt/AbstractMcpPromptMethodCallback.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.logaritex.mcp.annotation.McpArg;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.spec.McpSchema.Prompt;
@@ -143,7 +144,7 @@ public abstract class AbstractMcpPromptMethodCallback {
 			}
 			else {
 				// For individual argument parameters, extract from the request arguments
-				String paramName = param.getName();
+				String paramName = param.getAnnotation(McpArg.class).name();
 				if (request.arguments() != null && request.arguments().containsKey(paramName)) {
 					Object argValue = request.arguments().get(paramName);
 					args[i] = convertArgumentValue(argValue, paramType);

--- a/mcp-annotations/src/test/java/com/logaritex/mcp/method/prompt/SyncMcpPromptMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/com/logaritex/mcp/method/prompt/SyncMcpPromptMethodCallbackTests.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+import com.logaritex.mcp.annotation.McpArg;
 import com.logaritex.mcp.annotation.McpPrompt;
 import com.logaritex.mcp.method.prompt.SyncMcpPromptMethodCallback;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
@@ -55,13 +56,15 @@ public class SyncMcpPromptMethodCallbackTests {
 		}
 
 		@McpPrompt(name = "individual-args", description = "A prompt with individual arguments")
-		public GetPromptResult getPromptWithIndividualArgs(String name, Integer age) {
+		public GetPromptResult getPromptWithIndividualArgs(@McpArg(name = "name", description = "The user's name", required = true) String name,
+														   @McpArg(name = "age", description = "The user's age", required = true) Integer age) {
 			return new GetPromptResult("Individual arguments prompt", List.of(new PromptMessage(Role.ASSISTANT,
 					new TextContent("Hello " + name + ", you are " + age + " years old"))));
 		}
 
 		@McpPrompt(name = "mixed-args", description = "A prompt with mixed argument types")
-		public GetPromptResult getPromptWithMixedArgs(McpSyncServerExchange exchange, String name, Integer age) {
+		public GetPromptResult getPromptWithMixedArgs(McpSyncServerExchange exchange,@McpArg(name = "name", description = "The user's name", required = true) String name,
+													  @McpArg(name = "age", description = "The user's age", required = true) Integer age) {
 			return new GetPromptResult("Mixed arguments prompt", List.of(new PromptMessage(Role.ASSISTANT,
 					new TextContent("Hello " + name + ", you are " + age + " years old (with exchange)"))));
 		}


### PR DESCRIPTION
Fixes #3355
As mentioned in the issue, For the buildArgs method in the AbstractMcpPromptMethodcallbacks class, we fixed the issue of parameter mounting failure by changing the requested parameter from being mounted to the method parameter name to being mounted to the value of @McpArg. This PR fixes the issue and modifies the corresponding unit tests.