### PR TITLE
fixed: #6 this bug is that getDeclaredMethods returns an unstable list

### DIFF
--- a/mcp-annotations-spring/src/main/java/com/logaritex/mcp/spring/SyncMcpAnnotationProvider.java
+++ b/mcp-annotations-spring/src/main/java/com/logaritex/mcp/spring/SyncMcpAnnotationProvider.java
@@ -16,6 +16,8 @@
 package com.logaritex.mcp.spring;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -92,8 +94,12 @@ public class SyncMcpAnnotationProvider {
 
 		@Override
 		protected Method[] doGetClassMethods(Object bean) {
-			return ReflectionUtils
-				.getDeclaredMethods(AopUtils.isAopProxy(bean) ? AopUtils.getTargetClass(bean) : bean.getClass());
+			Method[] methods = ReflectionUtils
+					.getDeclaredMethods(AopUtils.isAopProxy(bean) ? AopUtils.getTargetClass(bean) : bean.getClass());
+			Arrays.sort(methods, Comparator
+					.comparing(Method::getName)
+					.thenComparing(method -> Arrays.toString(method.getParameterTypes())));
+			return methods;
 		}
 
 	}

--- a/mcp-annotations/src/main/java/com/logaritex/mcp/provider/SyncMcpLoggingConsumerProvider.java
+++ b/mcp-annotations/src/main/java/com/logaritex/mcp/provider/SyncMcpLoggingConsumerProvider.java
@@ -17,6 +17,8 @@
 package com.logaritex.mcp.provider;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -103,7 +105,11 @@ public class SyncMcpLoggingConsumerProvider {
 	 * @return the methods of the bean class
 	 */
 	protected Method[] doGetClassMethods(Object bean) {
-		return bean.getClass().getDeclaredMethods();
+		Method[] methods = bean.getClass().getDeclaredMethods();
+		Arrays.sort(methods, Comparator
+				.comparing(Method::getName)
+				.thenComparing(method -> Arrays.toString(method.getParameterTypes())));
+		return methods;
 	}
 
 }


### PR DESCRIPTION
bean. getClass(). getDeclaredMethods() in the doGetClassMethods method called in provider. getLoggingConsumers(), the order of the returned method list is not fixed, so values cannot be obtained through index