### PR TITLE
feat: add elicitation support to Spring annotation providers

### DIFF
--- a/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/AsyncMcpAnnotationProvider.java
+++ b/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/AsyncMcpAnnotationProvider.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.function.Function;
 
+import org.springaicommunity.mcp.provider.AsyncMcpElicitationProvider;
 import org.springaicommunity.mcp.provider.AsyncMcpLoggingConsumerProvider;
 import org.springaicommunity.mcp.provider.AsyncMcpSamplingProvider;
 import org.springaicommunity.mcp.provider.AsyncMcpToolProvider;
@@ -26,6 +27,8 @@ import org.springaicommunity.mcp.provider.AsyncMcpToolProvider;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 import reactor.core.publisher.Mono;
 
@@ -60,6 +63,19 @@ public class AsyncMcpAnnotationProvider {
 
 	}
 
+	private static class SpringAiAsyncMcpElicitationProvider extends AsyncMcpElicitationProvider {
+
+		public SpringAiAsyncMcpElicitationProvider(List<Object> elicitationObjects) {
+			super(elicitationObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
 	private static class SpringAiAsyncMcpToolProvider extends AsyncMcpToolProvider {
 
 		public SpringAiAsyncMcpToolProvider(List<Object> toolObjects) {
@@ -81,6 +97,11 @@ public class AsyncMcpAnnotationProvider {
 	public static Function<CreateMessageRequest, Mono<CreateMessageResult>> createAsyncSamplingHandler(
 			List<Object> samplingObjects) {
 		return new SpringAiAsyncMcpSamplingProvider(samplingObjects).getSamplingHandler();
+	}
+
+	public static Function<ElicitRequest, Mono<ElicitResult>> createAsyncElicitationHandler(
+			List<Object> elicitationObjects) {
+		return new SpringAiAsyncMcpElicitationProvider(elicitationObjects).getElicitationHandler();
 	}
 
 	public static List<AsyncToolSpecification> createAsyncToolSpecifications(List<Object> toolObjects) {

--- a/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/SyncMcpAnnotationProvider.java
+++ b/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/SyncMcpAnnotationProvider.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.springaicommunity.mcp.provider.SyncMcpCompletionProvider;
+import org.springaicommunity.mcp.provider.SyncMcpElicitationProvider;
 import org.springaicommunity.mcp.provider.SyncMcpLoggingConsumerProvider;
 import org.springaicommunity.mcp.provider.SyncMcpPromptProvider;
 import org.springaicommunity.mcp.provider.SyncMcpResourceProvider;
@@ -33,6 +34,8 @@ import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecificatio
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 
 /**
@@ -118,6 +121,19 @@ public class SyncMcpAnnotationProvider {
 
 	}
 
+	private static class SpringAiSyncMcpElicitationProvider extends SyncMcpElicitationProvider {
+
+		public SpringAiSyncMcpElicitationProvider(List<Object> elicitationObjects) {
+			super(elicitationObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
 	public static List<SyncToolSpecification> createSyncToolSpecifications(List<Object> toolObjects) {
 		return new SpringAiSyncToolProvider(toolObjects).getToolSpecifications();
 	}
@@ -141,6 +157,10 @@ public class SyncMcpAnnotationProvider {
 	public static Function<CreateMessageRequest, CreateMessageResult> createSyncSamplingHandler(
 			List<Object> samplingObjects) {
 		return new SpringAiSyncMcpSamplingProvider(samplingObjects).getSamplingHandler();
+	}
+
+	public static Function<ElicitRequest, ElicitResult> createSyncElicitationHandler(List<Object> elicitationObjects) {
+		return new SpringAiSyncMcpElicitationProvider(elicitationObjects).getElicitationHandler();
 	}
 
 }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpElicitation.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpElicitation.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for methods that handle elicitation requests from MCP servers.
+ *
+ * <p>
+ * Methods annotated with this annotation can be used to process elicitation requests from
+ * MCP servers.
+ *
+ * <p>
+ * For synchronous handlers, the method must return {@code ElicitResult}. For asynchronous
+ * handlers, the method must return {@code Mono<ElicitResult>}.
+ *
+ * <p>
+ * Example usage: <pre>{@code
+ * &#64;McpElicitation
+ * public ElicitResult handleElicitationRequest(ElicitRequest request) {
+ *     return ElicitResult.builder()
+ *         .message("Generated response")
+ *         .requestedSchema(
+ *             Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
+ *         .build();
+ * }
+ *
+ * &#64;McpElicitation
+ * public Mono<ElicitResult> handleAsyncElicitationRequest(ElicitRequest request) {
+ *     return Mono.just(ElicitResult.builder()
+ *         .message("Generated response")
+ *         .requestedSchema(
+ *             Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
+ *         .build());
+ * }
+ * }</pre>
+ *
+ * @author Christian Tzolov
+ * @see io.modelcontextprotocol.spec.McpSchema.ElicitRequest
+ * @see io.modelcontextprotocol.spec.McpSchema.ElicitResult
+ */
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface McpElicitation {
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/elicitation/AbstractMcpElicitationMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/elicitation/AbstractMcpElicitationMethodCallback.java
@@ -2,37 +2,37 @@
  * Copyright 2025-2025 the original author or authors.
  */
 
-package org.springaicommunity.mcp.method.sampling;
+package org.springaicommunity.mcp.method.elicitation;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 
-import org.springaicommunity.mcp.annotation.McpSampling;
+import org.springaicommunity.mcp.annotation.McpElicitation;
 
-import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
 import io.modelcontextprotocol.util.Assert;
 
 /**
- * Abstract base class for creating callbacks around sampling methods.
+ * Abstract base class for creating callbacks around elicitation methods.
  *
- * This class provides common functionality for both synchronous and asynchronous sampling
- * method callbacks. It contains shared logic for method validation, argument building,
- * and other common operations.
+ * This class provides common functionality for both synchronous and asynchronous
+ * elicitation method callbacks. It contains shared logic for method validation, argument
+ * building, and other common operations.
  *
  * @author Christian Tzolov
  */
-public abstract class AbstractMcpSamplingMethodCallback {
+public abstract class AbstractMcpElicitationMethodCallback {
 
 	protected final Method method;
 
 	protected final Object bean;
 
 	/**
-	 * Constructor for AbstractMcpSamplingMethodCallback.
+	 * Constructor for AbstractMcpElicitationMethodCallback.
 	 * @param method The method to create a callback for
 	 * @param bean The bean instance that contains the method
 	 */
-	protected AbstractMcpSamplingMethodCallback(Method method, Object bean) {
+	protected AbstractMcpElicitationMethodCallback(Method method, Object bean) {
 		Assert.notNull(method, "Method can't be null!");
 		Assert.notNull(bean, "Bean can't be null!");
 
@@ -42,7 +42,7 @@ public abstract class AbstractMcpSamplingMethodCallback {
 	}
 
 	/**
-	 * Validates that the method signature is compatible with the sampling callback.
+	 * Validates that the method signature is compatible with the elicitation callback.
 	 * <p>
 	 * This method checks that the return type is valid and that the parameters match the
 	 * expected pattern.
@@ -59,7 +59,7 @@ public abstract class AbstractMcpSamplingMethodCallback {
 	}
 
 	/**
-	 * Validates that the method return type is compatible with the sampling callback.
+	 * Validates that the method return type is compatible with the elicitation callback.
 	 * This method should be implemented by subclasses to handle specific return type
 	 * validation.
 	 * @param method The method to validate
@@ -79,27 +79,27 @@ public abstract class AbstractMcpSamplingMethodCallback {
 		// Check parameter count - must have at least 1 parameter
 		if (parameters.length < 1) {
 			throw new IllegalArgumentException(
-					"Method must have at least 1 parameter (CreateMessageRequest): " + method.getName() + " in "
+					"Method must have at least 1 parameter (ElicitRequest): " + method.getName() + " in "
 							+ method.getDeclaringClass().getName() + " has " + parameters.length + " parameters");
 		}
 
 		// Check parameter types
 		if (parameters.length == 1) {
-			// Single parameter must be CreateMessageRequest
-			if (!CreateMessageRequest.class.isAssignableFrom(parameters[0].getType())) {
-				throw new IllegalArgumentException("Single parameter must be of type CreateMessageRequest: "
-						+ method.getName() + " in " + method.getDeclaringClass().getName() + " has parameter of type "
+			// Single parameter must be ElicitRequest
+			if (!ElicitRequest.class.isAssignableFrom(parameters[0].getType())) {
+				throw new IllegalArgumentException("Single parameter must be of type ElicitRequest: " + method.getName()
+						+ " in " + method.getDeclaringClass().getName() + " has parameter of type "
 						+ parameters[0].getType().getName());
 			}
 		}
 		else {
-			// TODO: Support for multiple parameters corresponding to CreateMessageRequest
+			// TODO: Support for multiple parameters corresponding to ElicitRequest
 			// fields
 			// For now, we only support the single parameter version
 			throw new IllegalArgumentException(
-					"Currently only methods with a single CreateMessageRequest parameter are supported: "
-							+ method.getName() + " in " + method.getDeclaringClass().getName() + " has "
-							+ parameters.length + " parameters");
+					"Currently only methods with a single ElicitRequest parameter are supported: " + method.getName()
+							+ " in " + method.getDeclaringClass().getName() + " has " + parameters.length
+							+ " parameters");
 		}
 	}
 
@@ -110,23 +110,23 @@ public abstract class AbstractMcpSamplingMethodCallback {
 	 * and the available values (exchange, request).
 	 * @param method The method to build arguments for
 	 * @param exchange The server exchange
-	 * @param request The sampling request
+	 * @param request The elicitation request
 	 * @return An array of arguments for the method invocation
 	 */
-	protected Object[] buildArgs(Method method, Object exchange, CreateMessageRequest request) {
+	protected Object[] buildArgs(Method method, Object exchange, ElicitRequest request) {
 		Parameter[] parameters = method.getParameters();
 		Object[] args = new Object[parameters.length];
 
 		if (parameters.length == 1) {
-			// Single parameter (CreateMessageRequest)
+			// Single parameter (ElicitRequest)
 			args[0] = request;
 		}
 		else {
-			// TODO: Support for multiple parameters corresponding to CreateMessageRequest
+			// TODO: Support for multiple parameters corresponding to ElicitRequest
 			// fields
 			// For now, we only support the single parameter version
 			throw new IllegalArgumentException(
-					"Currently only methods with a single CreateMessageRequest parameter are supported");
+					"Currently only methods with a single ElicitRequest parameter are supported");
 		}
 
 		return args;
@@ -142,9 +142,9 @@ public abstract class AbstractMcpSamplingMethodCallback {
 	protected abstract boolean isExchangeType(Class<?> paramType);
 
 	/**
-	 * Exception thrown when there is an error invoking a sampling method.
+	 * Exception thrown when there is an error invoking an elicitation method.
 	 */
-	public static class McpSamplingMethodException extends RuntimeException {
+	public static class McpElicitationMethodException extends RuntimeException {
 
 		private static final long serialVersionUID = 1L;
 
@@ -153,7 +153,7 @@ public abstract class AbstractMcpSamplingMethodCallback {
 		 * @param message The detail message
 		 * @param cause The cause
 		 */
-		public McpSamplingMethodException(String message, Throwable cause) {
+		public McpElicitationMethodException(String message, Throwable cause) {
 			super(message, cause);
 		}
 
@@ -161,14 +161,14 @@ public abstract class AbstractMcpSamplingMethodCallback {
 		 * Constructs a new exception with the specified detail message.
 		 * @param message The detail message
 		 */
-		public McpSamplingMethodException(String message) {
+		public McpElicitationMethodException(String message) {
 			super(message);
 		}
 
 	}
 
 	/**
-	 * Abstract builder for creating McpSamplingMethodCallback instances.
+	 * Abstract builder for creating McpElicitationMethodCallback instances.
 	 * <p>
 	 * This builder provides a base for constructing callback instances with the required
 	 * parameters.
@@ -205,12 +205,12 @@ public abstract class AbstractMcpSamplingMethodCallback {
 		}
 
 		/**
-		 * Set the sampling annotation.
-		 * @param sampling The sampling annotation
+		 * Set the elicitation annotation.
+		 * @param elicitation The elicitation annotation
 		 * @return This builder
 		 */
 		@SuppressWarnings("unchecked")
-		public T sampling(McpSampling sampling) {
+		public T elicitation(McpElicitation elicitation) {
 			// No additional configuration needed from the annotation at this time
 			return (T) this;
 		}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/elicitation/AsyncMcpElicitationMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/elicitation/AsyncMcpElicitationMethodCallback.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.elicitation;
+
+import java.lang.reflect.Method;
+import java.util.function.Function;
+
+import org.springaicommunity.mcp.annotation.McpElicitation;
+
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+import reactor.core.publisher.Mono;
+
+/**
+ * Class for creating Function callbacks around elicitation methods that return Mono.
+ *
+ * This class provides a way to convert methods annotated with {@link McpElicitation} into
+ * callback functions that can be used to handle elicitation requests in a reactive way.
+ * It supports methods with a single ElicitRequest parameter.
+ *
+ * @author Christian Tzolov
+ */
+public final class AsyncMcpElicitationMethodCallback extends AbstractMcpElicitationMethodCallback
+		implements Function<ElicitRequest, Mono<ElicitResult>> {
+
+	private AsyncMcpElicitationMethodCallback(Builder builder) {
+		super(builder.method, builder.bean);
+	}
+
+	/**
+	 * Apply the callback to the given request.
+	 * <p>
+	 * This method builds the arguments for the method call, invokes the method, and
+	 * returns a Mono that completes with the result.
+	 * @param request The elicitation request, must not be null
+	 * @return A Mono that completes with the result of the method invocation
+	 * @throws McpElicitationMethodException if there is an error invoking the elicitation
+	 * method
+	 * @throws IllegalArgumentException if the request is null
+	 */
+	@Override
+	public Mono<ElicitResult> apply(ElicitRequest request) {
+		if (request == null) {
+			return Mono.error(new IllegalArgumentException("Request must not be null"));
+		}
+
+		try {
+			// Build arguments for the method call
+			Object[] args = this.buildArgs(this.method, null, request);
+
+			// Invoke the method
+			this.method.setAccessible(true);
+			Object result = this.method.invoke(this.bean, args);
+
+			// If the method returns a Mono, handle it
+			if (result instanceof Mono) {
+				@SuppressWarnings("unchecked")
+				Mono<ElicitResult> monoResult = (Mono<ElicitResult>) result;
+				return monoResult;
+			}
+			// If the method returns an ElicitResult directly, wrap it in a Mono
+			else if (result instanceof ElicitResult) {
+				return Mono.just((ElicitResult) result);
+			}
+			// Otherwise, throw an exception
+			else {
+				return Mono.error(new McpElicitationMethodException(
+						"Method must return Mono<ElicitResult> or ElicitResult: " + this.method.getName()));
+			}
+		}
+		catch (Exception e) {
+			return Mono.error(new McpElicitationMethodException(
+					"Error invoking elicitation method: " + this.method.getName(), e));
+		}
+	}
+
+	/**
+	 * Validates that the method return type is compatible with the elicitation callback.
+	 * @param method The method to validate
+	 * @throws IllegalArgumentException if the return type is not compatible
+	 */
+	@Override
+	protected void validateReturnType(Method method) {
+		Class<?> returnType = method.getReturnType();
+
+		if (!Mono.class.isAssignableFrom(returnType) && !ElicitResult.class.isAssignableFrom(returnType)) {
+			throw new IllegalArgumentException(
+					"Method must return Mono<ElicitResult> or ElicitResult: " + method.getName() + " in "
+							+ method.getDeclaringClass().getName() + " returns " + returnType.getName());
+		}
+	}
+
+	/**
+	 * Checks if a parameter type is compatible with the exchange type.
+	 * @param paramType The parameter type to check
+	 * @return true if the parameter type is compatible with the exchange type, false
+	 * otherwise
+	 */
+	@Override
+	protected boolean isExchangeType(Class<?> paramType) {
+		// No exchange type for elicitation methods
+		return false;
+	}
+
+	/**
+	 * Builder for creating AsyncMcpElicitationMethodCallback instances.
+	 * <p>
+	 * This builder provides a fluent API for constructing
+	 * AsyncMcpElicitationMethodCallback instances with the required parameters.
+	 */
+	public static class Builder extends AbstractBuilder<Builder, AsyncMcpElicitationMethodCallback> {
+
+		/**
+		 * Build the callback.
+		 * @return A new AsyncMcpElicitationMethodCallback instance
+		 */
+		@Override
+		public AsyncMcpElicitationMethodCallback build() {
+			validate();
+			return new AsyncMcpElicitationMethodCallback(this);
+		}
+
+	}
+
+	/**
+	 * Create a new builder.
+	 * @return A new builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/elicitation/SyncMcpElicitationMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/elicitation/SyncMcpElicitationMethodCallback.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.elicitation;
+
+import java.lang.reflect.Method;
+import java.util.function.Function;
+
+import org.springaicommunity.mcp.annotation.McpElicitation;
+
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+
+/**
+ * Class for creating Function callbacks around elicitation methods.
+ *
+ * This class provides a way to convert methods annotated with {@link McpElicitation} into
+ * callback functions that can be used to handle elicitation requests. It supports methods
+ * with a single ElicitRequest parameter.
+ *
+ * @author Christian Tzolov
+ */
+public final class SyncMcpElicitationMethodCallback extends AbstractMcpElicitationMethodCallback
+		implements Function<ElicitRequest, ElicitResult> {
+
+	private SyncMcpElicitationMethodCallback(Builder builder) {
+		super(builder.method, builder.bean);
+	}
+
+	/**
+	 * Apply the callback to the given request.
+	 * <p>
+	 * This method builds the arguments for the method call, invokes the method, and
+	 * returns the result.
+	 * @param request The elicitation request, must not be null
+	 * @return The result of the method invocation
+	 * @throws McpElicitationMethodException if there is an error invoking the elicitation
+	 * method
+	 * @throws IllegalArgumentException if the request is null
+	 */
+	@Override
+	public ElicitResult apply(ElicitRequest request) {
+		if (request == null) {
+			throw new IllegalArgumentException("Request must not be null");
+		}
+
+		try {
+			// Build arguments for the method call
+			Object[] args = this.buildArgs(this.method, null, request);
+
+			// Invoke the method
+			this.method.setAccessible(true);
+			Object result = this.method.invoke(this.bean, args);
+
+			// Return the result
+			return (ElicitResult) result;
+		}
+		catch (Exception e) {
+			throw new McpElicitationMethodException("Error invoking elicitation method: " + this.method.getName(), e);
+		}
+	}
+
+	/**
+	 * Validates that the method return type is compatible with the elicitation callback.
+	 * @param method The method to validate
+	 * @throws IllegalArgumentException if the return type is not compatible
+	 */
+	@Override
+	protected void validateReturnType(Method method) {
+		Class<?> returnType = method.getReturnType();
+
+		if (!ElicitResult.class.isAssignableFrom(returnType)) {
+			throw new IllegalArgumentException("Method must return ElicitResult: " + method.getName() + " in "
+					+ method.getDeclaringClass().getName() + " returns " + returnType.getName());
+		}
+	}
+
+	/**
+	 * Checks if a parameter type is compatible with the exchange type.
+	 * @param paramType The parameter type to check
+	 * @return true if the parameter type is compatible with the exchange type, false
+	 * otherwise
+	 */
+	@Override
+	protected boolean isExchangeType(Class<?> paramType) {
+		// No exchange type for elicitation methods
+		return false;
+	}
+
+	/**
+	 * Builder for creating SyncMcpElicitationMethodCallback instances.
+	 * <p>
+	 * This builder provides a fluent API for constructing
+	 * SyncMcpElicitationMethodCallback instances with the required parameters.
+	 */
+	public static class Builder extends AbstractBuilder<Builder, SyncMcpElicitationMethodCallback> {
+
+		/**
+		 * Build the callback.
+		 * @return A new SyncMcpElicitationMethodCallback instance
+		 */
+		@Override
+		public SyncMcpElicitationMethodCallback build() {
+			validate();
+			return new SyncMcpElicitationMethodCallback(this);
+		}
+
+	}
+
+	/**
+	 * Create a new builder.
+	 * @return A new builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/AsyncMcpElicitationProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/AsyncMcpElicitationProvider.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.provider;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.method.elicitation.AsyncMcpElicitationMethodCallback;
+
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+import io.modelcontextprotocol.util.Assert;
+import reactor.core.publisher.Mono;
+
+/**
+ * Provider for asynchronous elicitation callbacks.
+ *
+ * <p>
+ * This class scans a list of objects for methods annotated with {@link McpElicitation}
+ * and creates {@link Function} callbacks for them. These callbacks can be used to handle
+ * elicitation requests from MCP servers in a reactive way.
+ *
+ * <p>
+ * Example usage: <pre>{@code
+ * // Create a provider with a list of objects containing @McpElicitation methods
+ * AsyncMcpElicitationProvider provider = new AsyncMcpElicitationProvider(List.of(elicitationHandler));
+ *
+ * // Get the elicitation handler
+ * Function<ElicitRequest, Mono<ElicitResult>> elicitationHandler = provider.getElicitationHandler();
+ *
+ * // Add the handler to the client features
+ * McpClientFeatures.Async clientFeatures = new McpClientFeatures.Async(
+ *     clientInfo, clientCapabilities, roots,
+ *     toolsChangeConsumers, resourcesChangeConsumers, promptsChangeConsumers,
+ *     loggingConsumers, samplingHandler, elicitationHandler);
+ * }</pre>
+ *
+ * @author Christian Tzolov
+ * @see McpElicitation
+ * @see AsyncMcpElicitationMethodCallback
+ * @see ElicitRequest
+ * @see ElicitResult
+ */
+public class AsyncMcpElicitationProvider {
+
+	private final List<Object> elicitationObjects;
+
+	/**
+	 * Create a new AsyncMcpElicitationProvider.
+	 * @param elicitationObjects the objects containing methods annotated with
+	 * {@link McpElicitation}
+	 */
+	public AsyncMcpElicitationProvider(List<Object> elicitationObjects) {
+		Assert.notNull(elicitationObjects, "elicitationObjects cannot be null");
+		this.elicitationObjects = elicitationObjects;
+	}
+
+	/**
+	 * Get the elicitation handler.
+	 * @return the elicitation handler
+	 * @throws IllegalStateException if no elicitation methods are found or if multiple
+	 * elicitation methods are found
+	 */
+	public Function<ElicitRequest, Mono<ElicitResult>> getElicitationHandler() {
+		List<Function<ElicitRequest, Mono<ElicitResult>>> elicitationHandlers = this.elicitationObjects.stream()
+			.map(elicitationObject -> Stream.of(doGetClassMethods(elicitationObject))
+				.filter(method -> method.isAnnotationPresent(McpElicitation.class))
+				.filter(method -> method.getParameterCount() == 1
+						&& ElicitRequest.class.isAssignableFrom(method.getParameterTypes()[0]))
+				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
+						|| ElicitResult.class.isAssignableFrom(method.getReturnType()))
+				.map(mcpElicitationMethod -> {
+					var elicitationAnnotation = mcpElicitationMethod.getAnnotation(McpElicitation.class);
+
+					Function<ElicitRequest, Mono<ElicitResult>> methodCallback = AsyncMcpElicitationMethodCallback
+						.builder()
+						.method(mcpElicitationMethod)
+						.bean(elicitationObject)
+						.elicitation(elicitationAnnotation)
+						.build();
+
+					return methodCallback;
+				})
+				.toList())
+			.flatMap(List::stream)
+			.toList();
+
+		if (elicitationHandlers.isEmpty()) {
+			throw new IllegalStateException("No elicitation methods found");
+		}
+		if (elicitationHandlers.size() > 1) {
+			throw new IllegalStateException("Multiple elicitation methods found: " + elicitationHandlers.size());
+		}
+
+		return elicitationHandlers.get(0);
+	}
+
+	/**
+	 * Returns the methods of the given bean class.
+	 * @param bean the bean instance
+	 * @return the methods of the bean class
+	 */
+	protected Method[] doGetClassMethods(Object bean) {
+		return bean.getClass().getDeclaredMethods();
+	}
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/SyncMcpElicitationProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/SyncMcpElicitationProvider.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.provider;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.method.elicitation.SyncMcpElicitationMethodCallback;
+
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+import io.modelcontextprotocol.util.Assert;
+import reactor.core.publisher.Mono;
+
+/**
+ * Provider for synchronous elicitation callbacks.
+ *
+ * <p>
+ * This class scans a list of objects for methods annotated with {@link McpElicitation}
+ * and creates {@link Function} callbacks for them. These callbacks can be used to handle
+ * elicitation requests from MCP servers.
+ *
+ * <p>
+ * Example usage: <pre>{@code
+ * // Create a provider with a list of objects containing @McpElicitation methods
+ * SyncMcpElicitationProvider provider = new SyncMcpElicitationProvider(List.of(elicitationHandler));
+ *
+ * // Get the elicitation handler
+ * Function<ElicitRequest, ElicitResult> elicitationHandler = provider.getElicitationHandler();
+ *
+ * // Add the handler to the client features
+ * McpClientFeatures.Sync clientFeatures = new McpClientFeatures.Sync(
+ *     clientInfo, clientCapabilities, roots,
+ *     toolsChangeConsumers, resourcesChangeConsumers, promptsChangeConsumers,
+ *     loggingConsumers, samplingHandler, elicitationHandler);
+ * }</pre>
+ *
+ * @author Christian Tzolov
+ * @see McpElicitation
+ * @see SyncMcpElicitationMethodCallback
+ * @see ElicitRequest
+ * @see ElicitResult
+ */
+public class SyncMcpElicitationProvider {
+
+	private final List<Object> elicitationObjects;
+
+	/**
+	 * Create a new SyncMcpElicitationProvider.
+	 * @param elicitationObjects the objects containing methods annotated with
+	 * {@link McpElicitation}
+	 */
+	public SyncMcpElicitationProvider(List<Object> elicitationObjects) {
+		Assert.notNull(elicitationObjects, "elicitationObjects cannot be null");
+		this.elicitationObjects = elicitationObjects;
+	}
+
+	/**
+	 * Get the elicitation handler.
+	 * @return the elicitation handler
+	 * @throws IllegalStateException if no elicitation methods are found or if multiple
+	 * elicitation methods are found
+	 */
+	public Function<ElicitRequest, ElicitResult> getElicitationHandler() {
+		List<Function<ElicitRequest, ElicitResult>> elicitationHandlers = this.elicitationObjects.stream()
+			.map(elicitationObject -> Stream.of(doGetClassMethods(elicitationObject))
+				.filter(method -> method.isAnnotationPresent(McpElicitation.class))
+				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.filter(method -> ElicitResult.class.isAssignableFrom(method.getReturnType()))
+				.filter(method -> method.getParameterCount() == 1
+						&& ElicitRequest.class.isAssignableFrom(method.getParameterTypes()[0]))
+				.map(mcpElicitationMethod -> {
+					var elicitationAnnotation = mcpElicitationMethod.getAnnotation(McpElicitation.class);
+
+					Function<ElicitRequest, ElicitResult> methodCallback = SyncMcpElicitationMethodCallback.builder()
+						.method(mcpElicitationMethod)
+						.bean(elicitationObject)
+						.elicitation(elicitationAnnotation)
+						.build();
+
+					return methodCallback;
+				})
+				.toList())
+			.flatMap(List::stream)
+			.toList();
+
+		if (elicitationHandlers.isEmpty()) {
+			throw new IllegalStateException("No elicitation methods found");
+		}
+		if (elicitationHandlers.size() > 1) {
+			throw new IllegalStateException("Multiple elicitation methods found: " + elicitationHandlers.size());
+		}
+
+		return elicitationHandlers.get(0);
+	}
+
+	/**
+	 * Returns the methods of the given bean class.
+	 * @param bean the bean instance
+	 * @return the methods of the bean class
+	 */
+	protected Method[] doGetClassMethods(Object bean) {
+		return bean.getClass().getDeclaredMethods();
+	}
+
+}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/elicitation/AsyncMcpElicitationMethodCallbackExample.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/elicitation/AsyncMcpElicitationMethodCallbackExample.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.elicitation;
+
+import java.util.Map;
+
+import org.springaicommunity.mcp.annotation.McpElicitation;
+
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+import reactor.core.publisher.Mono;
+
+/**
+ * Example class demonstrating asynchronous elicitation method usage.
+ *
+ * @author Christian Tzolov
+ */
+public class AsyncMcpElicitationMethodCallbackExample {
+
+	@McpElicitation
+	public Mono<ElicitResult> handleElicitationRequest(ElicitRequest request) {
+		// Example implementation that accepts the request and returns some content
+		return Mono.just(new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("userInput", "Example async user input",
+				"confirmed", true, "timestamp", System.currentTimeMillis())));
+	}
+
+	@McpElicitation
+	public Mono<ElicitResult> handleDeclineElicitationRequest(ElicitRequest request) {
+		// Example implementation that declines the request after a delay
+		return Mono.delay(java.time.Duration.ofMillis(100))
+			.then(Mono.just(new ElicitResult(ElicitResult.Action.DECLINE, null)));
+	}
+
+	@McpElicitation
+	public ElicitResult handleSyncElicitationRequest(ElicitRequest request) {
+		// Example implementation that returns synchronously but will be wrapped in Mono
+		return new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("syncResponse",
+				"This was returned synchronously but wrapped in Mono", "requestMessage", request.message()));
+	}
+
+	@McpElicitation
+	public Mono<ElicitResult> handleCancelElicitationRequest(ElicitRequest request) {
+		// Example implementation that cancels the request
+		return Mono.just(new ElicitResult(ElicitResult.Action.CANCEL, null));
+	}
+
+}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/elicitation/SyncMcpElicitationMethodCallbackExample.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/elicitation/SyncMcpElicitationMethodCallbackExample.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.elicitation;
+
+import java.util.Map;
+
+import org.springaicommunity.mcp.annotation.McpElicitation;
+
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+
+/**
+ * Example class demonstrating synchronous elicitation method usage.
+ *
+ * @author Christian Tzolov
+ */
+public class SyncMcpElicitationMethodCallbackExample {
+
+	@McpElicitation
+	public ElicitResult handleElicitationRequest(ElicitRequest request) {
+		// Example implementation that accepts the request and returns some content
+		return new ElicitResult(ElicitResult.Action.ACCEPT,
+				Map.of("userInput", "Example user input", "confirmed", true));
+	}
+
+	@McpElicitation
+	public ElicitResult handleDeclineElicitationRequest(ElicitRequest request) {
+		// Example implementation that declines the request
+		return new ElicitResult(ElicitResult.Action.DECLINE, null);
+	}
+
+	@McpElicitation
+	public ElicitResult handleCancelElicitationRequest(ElicitRequest request) {
+		// Example implementation that cancels the request
+		return new ElicitResult(ElicitResult.Action.CANCEL, null);
+	}
+
+}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/AsyncMcpElicitationProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/AsyncMcpElicitationProviderTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.annotation.McpElicitation;
+
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * Tests for {@link AsyncMcpElicitationProvider}.
+ *
+ * @author Christian Tzolov
+ */
+public class AsyncMcpElicitationProviderTests {
+
+	@Test
+	public void testGetElicitationHandler() {
+		var provider = new AsyncMcpElicitationProvider(List.of(new TestElicitationHandler()));
+		Function<ElicitRequest, Mono<ElicitResult>> handler = provider.getElicitationHandler();
+
+		assertNotNull(handler);
+
+		ElicitRequest request = new ElicitRequest("Please provide your name",
+				Map.of("type", "object", "properties", Map.of("name", Map.of("type", "string"))));
+		Mono<ElicitResult> result = handler.apply(request);
+
+		StepVerifier.create(result).assertNext(elicitResult -> {
+			assertEquals(ElicitResult.Action.ACCEPT, elicitResult.action());
+			assertNotNull(elicitResult.content());
+			assertEquals("Async Test User", elicitResult.content().get("name"));
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testGetElicitationHandlerWithSyncMethod() {
+		var provider = new AsyncMcpElicitationProvider(List.of(new SyncElicitationHandler()));
+		Function<ElicitRequest, Mono<ElicitResult>> handler = provider.getElicitationHandler();
+
+		assertNotNull(handler);
+
+		ElicitRequest request = new ElicitRequest("Please provide your name",
+				Map.of("type", "object", "properties", Map.of("name", Map.of("type", "string"))));
+		Mono<ElicitResult> result = handler.apply(request);
+
+		StepVerifier.create(result).assertNext(elicitResult -> {
+			assertEquals(ElicitResult.Action.ACCEPT, elicitResult.action());
+			assertNotNull(elicitResult.content());
+			assertEquals("Sync Test User", elicitResult.content().get("name"));
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testNoElicitationMethods() {
+		var provider = new AsyncMcpElicitationProvider(List.of(new Object()));
+
+		assertThrows(IllegalStateException.class, () -> provider.getElicitationHandler(),
+				"No elicitation methods found");
+	}
+
+	@Test
+	public void testMultipleElicitationMethods() {
+		var provider = new AsyncMcpElicitationProvider(List.of(new MultipleElicitationHandler()));
+
+		assertThrows(IllegalStateException.class, () -> provider.getElicitationHandler(),
+				"Multiple elicitation methods found");
+	}
+
+	public static class TestElicitationHandler {
+
+		@McpElicitation
+		public Mono<ElicitResult> handleElicitation(ElicitRequest request) {
+			return Mono.just(new ElicitResult(ElicitResult.Action.ACCEPT,
+					Map.of("name", "Async Test User", "message", request.message())));
+		}
+
+	}
+
+	public static class SyncElicitationHandler {
+
+		@McpElicitation
+		public ElicitResult handleElicitation(ElicitRequest request) {
+			return new ElicitResult(ElicitResult.Action.ACCEPT,
+					Map.of("name", "Sync Test User", "message", request.message()));
+		}
+
+	}
+
+	public static class MultipleElicitationHandler {
+
+		@McpElicitation
+		public Mono<ElicitResult> handleElicitation1(ElicitRequest request) {
+			return Mono.just(new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("handler", "1")));
+		}
+
+		@McpElicitation
+		public Mono<ElicitResult> handleElicitation2(ElicitRequest request) {
+			return Mono.just(new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("handler", "2")));
+		}
+
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 
-		<mcp.java.sdk.version>0.11.0-SNAPSHOT</mcp.java.sdk.version>
+		<mcp.java.sdk.version>0.12.0-SNAPSHOT</mcp.java.sdk.version>
 		<spring-ai.version>1.1.0-SNAPSHOT</spring-ai.version>
 
 		<slf4j-api.version>2.0.16</slf4j-api.version>


### PR DESCRIPTION
- Add createAsyncElicitationHandler() method to AsyncMcpAnnotationProvider
- Add createSyncElicitationHandler() method to SyncMcpAnnotationProvider
- Implement SpringAiAsyncMcpElicitationProvider inner class
- Implement SpringAiSyncMcpElicitationProvider inner class
- Add ElicitRequest and ElicitResult imports to both providers
- Update README with comprehensive elicitation documentation:
  - Add elicitation to core module operations list
  - Document @McpElicitation annotation
  - Add elicitation method callbacks documentation
  - Add elicitation providers documentation
  - Include complete usage examples for sync and async handlers
  - Add Spring integration examples for elicitation
- Bump MCP Java SDK version from 0.11.0-SNAPSHOT to 0.12.0-SNAPSHOT

This enables Spring applications to easily integrate MCP elicitation functionality using the familiar annotation-based approach, providing both synchronous and asynchronous implementations for gathering additional information from users.