### PR TITLE
feat: add client-specific support and refactor to specification-based architecture

### DIFF
--- a/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/AsyncMcpAnnotationProvider.java
+++ b/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/AsyncMcpAnnotationProvider.java
@@ -17,8 +17,10 @@ package org.springaicommunity.mcp.spring;
 
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.function.Function;
 
+import org.springaicommunity.mcp.method.elicitation.AsyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.AsyncLoggingSpecification;
+import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
 import org.springaicommunity.mcp.provider.AsyncMcpElicitationProvider;
 import org.springaicommunity.mcp.provider.AsyncMcpLoggingConsumerProvider;
 import org.springaicommunity.mcp.provider.AsyncMcpSamplingProvider;
@@ -29,12 +31,6 @@ import org.springaicommunity.mcp.provider.AsyncStatelessMcpToolProvider;
 
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
-import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
-import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
-import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
-import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
-import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
-import reactor.core.publisher.Mono;
 
 /**
  * @author Christian Tzolov
@@ -132,19 +128,17 @@ public class AsyncMcpAnnotationProvider {
 
 	}
 
-	public static List<Function<LoggingMessageNotification, Mono<Void>>> createAsyncLoggingConsumers(
-			List<Object> loggingObjects) {
-		return new SpringAiAsyncMcpLoggingConsumerProvider(loggingObjects).getLoggingConsumers();
+	public static List<AsyncLoggingSpecification> createAsyncLoggingSpecifications(List<Object> loggingObjects) {
+		return new SpringAiAsyncMcpLoggingConsumerProvider(loggingObjects).getLoggingSpecifications();
 	}
 
-	public static Function<CreateMessageRequest, Mono<CreateMessageResult>> createAsyncSamplingHandler(
-			List<Object> samplingObjects) {
-		return new SpringAiAsyncMcpSamplingProvider(samplingObjects).getSamplingHandler();
+	public static List<AsyncSamplingSpecification> createAsyncSamplingSpecifications(List<Object> samplingObjects) {
+		return new SpringAiAsyncMcpSamplingProvider(samplingObjects).getSamplingSpecifictions();
 	}
 
-	public static Function<ElicitRequest, Mono<ElicitResult>> createAsyncElicitationHandler(
+	public static List<AsyncElicitationSpecification> createAsyncElicitationSpecifications(
 			List<Object> elicitationObjects) {
-		return new SpringAiAsyncMcpElicitationProvider(elicitationObjects).getElicitationHandler();
+		return new SpringAiAsyncMcpElicitationProvider(elicitationObjects).getElicitationSpecifications();
 	}
 
 	public static List<AsyncToolSpecification> createAsyncToolSpecifications(List<Object> toolObjects) {

--- a/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/SyncMcpAnnotationProvider.java
+++ b/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/SyncMcpAnnotationProvider.java
@@ -17,9 +17,10 @@ package org.springaicommunity.mcp.spring;
 
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
+import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
 import org.springaicommunity.mcp.provider.SyncMcpCompletionProvider;
 import org.springaicommunity.mcp.provider.SyncMcpElicitationProvider;
 import org.springaicommunity.mcp.provider.SyncMcpLoggingConsumerProvider;
@@ -36,11 +37,6 @@ import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
-import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
-import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
-import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
-import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
-import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 
 /**
  * @author Christian Tzolov
@@ -208,17 +204,17 @@ public class SyncMcpAnnotationProvider {
 		return new SpringAiSyncStatelessResourceProvider(resourceObjects).getResourceSpecifications();
 	}
 
-	public static List<Consumer<LoggingMessageNotification>> createSyncLoggingConsumers(List<Object> loggingObjects) {
-		return new SpringAiSyncMcpLoggingConsumerProvider(loggingObjects).getLoggingConsumers();
+	public static List<SyncLoggingSpecification> createSyncLoggingSpecifications(List<Object> loggingObjects) {
+		return new SpringAiSyncMcpLoggingConsumerProvider(loggingObjects).getLoggingSpecifications();
 	}
 
-	public static Function<CreateMessageRequest, CreateMessageResult> createSyncSamplingHandler(
-			List<Object> samplingObjects) {
-		return new SpringAiSyncMcpSamplingProvider(samplingObjects).getSamplingHandler();
+	public static List<SyncSamplingSpecification> createSyncSamplingSpecifications(List<Object> samplingObjects) {
+		return new SpringAiSyncMcpSamplingProvider(samplingObjects).getSamplingSpecifications();
 	}
 
-	public static Function<ElicitRequest, ElicitResult> createSyncElicitationHandler(List<Object> elicitationObjects) {
-		return new SpringAiSyncMcpElicitationProvider(elicitationObjects).getElicitationHandler();
+	public static List<SyncElicitationSpecification> createSyncElicitationSpecifications(
+			List<Object> elicitationObjects) {
+		return new SpringAiSyncMcpElicitationProvider(elicitationObjects).getElicitationSpecifications();
 	}
 
 }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpElicitation.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpElicitation.java
@@ -51,4 +51,10 @@ import java.lang.annotation.Target;
 @Documented
 public @interface McpElicitation {
 
+	/**
+	 * Used as connection or client identifier to select the MCP client, the elicitation
+	 * method is associated with. If not specified, is applied to all clients.
+	 */
+	String clientId() default "";
+
 }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpLoggingConsumer.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpLoggingConsumer.java
@@ -50,4 +50,10 @@ import java.lang.annotation.Target;
 @Documented
 public @interface McpLoggingConsumer {
 
+	/**
+	 * Used as connection or client identifier to select the MCP client, the logging
+	 * consumer is associated with. If not specified, is applied to all clients.
+	 */
+	String clientId() default "";
+
 }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpSampling.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpSampling.java
@@ -53,4 +53,10 @@ import java.lang.annotation.Target;
 @Documented
 public @interface McpSampling {
 
+	/**
+	 * Used as connection or client identifier to select the MCP client, the sampling
+	 * method is associated with. If not specified, is applied to all clients.
+	 */
+	String clientId() default "";
+
 }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/elicitation/AsyncElicitationSpecification.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/elicitation/AsyncElicitationSpecification.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.elicitation;
+
+import java.util.function.Function;
+
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+import reactor.core.publisher.Mono;
+
+public record AsyncElicitationSpecification(String clientId,
+		Function<ElicitRequest, Mono<ElicitResult>> elicitationHandler) {
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/elicitation/SyncElicitationSpecification.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/elicitation/SyncElicitationSpecification.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.elicitation;
+
+import java.util.function.Function;
+
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+
+public record SyncElicitationSpecification(String clientId, Function<ElicitRequest, ElicitResult> elicitationHandler) {
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/logging/AsyncLoggingSpecification.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/logging/AsyncLoggingSpecification.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.logging;
+
+import java.util.function.Function;
+
+import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
+import reactor.core.publisher.Mono;
+
+public record AsyncLoggingSpecification(String clientId,
+		Function<LoggingMessageNotification, Mono<Void>> loggingHandler) {
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/logging/SyncLoggingSpecification.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/logging/SyncLoggingSpecification.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.logging;
+
+import java.util.function.Consumer;
+
+import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
+
+public record SyncLoggingSpecification(String clientId, Consumer<LoggingMessageNotification> loggingHandler) {
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/sampling/AsyncSamplingSpecification.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/sampling/AsyncSamplingSpecification.java
@@ -1,0 +1,12 @@
+package org.springaicommunity.mcp.method.sampling;
+
+import java.util.function.Function;
+
+import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
+import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
+import reactor.core.publisher.Mono;
+
+public record AsyncSamplingSpecification(String clientId,
+		Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler) {
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/sampling/SyncSamplingSpecification.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/sampling/SyncSamplingSpecification.java
@@ -1,0 +1,11 @@
+package org.springaicommunity.mcp.method.sampling;
+
+import java.util.function.Function;
+
+import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
+import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
+
+public record SyncSamplingSpecification(String clientId,
+		Function<CreateMessageRequest, CreateMessageResult> samplingHandler) {
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/AsyncMcpElicitationProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/AsyncMcpElicitationProvider.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.method.elicitation.AsyncElicitationSpecification;
 import org.springaicommunity.mcp.method.elicitation.AsyncMcpElicitationMethodCallback;
 
 import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
@@ -73,13 +74,13 @@ public class AsyncMcpElicitationProvider {
 	}
 
 	/**
-	 * Get the elicitation handler.
-	 * @return the elicitation handler
+	 * Get the elicitation specifications.
+	 * @return the elicitation specifications
 	 * @throws IllegalStateException if no elicitation methods are found or if multiple
 	 * elicitation methods are found
 	 */
-	public Function<ElicitRequest, Mono<ElicitResult>> getElicitationHandler() {
-		List<Function<ElicitRequest, Mono<ElicitResult>>> elicitationHandlers = this.elicitationObjects.stream()
+	public List<AsyncElicitationSpecification> getElicitationSpecifications() {
+		List<AsyncElicitationSpecification> elicitationHandlers = this.elicitationObjects.stream()
 			.map(elicitationObject -> Stream.of(doGetClassMethods(elicitationObject))
 				.filter(method -> method.isAnnotationPresent(McpElicitation.class))
 				.filter(method -> method.getParameterCount() == 1
@@ -96,7 +97,7 @@ public class AsyncMcpElicitationProvider {
 						.elicitation(elicitationAnnotation)
 						.build();
 
-					return methodCallback;
+					return new AsyncElicitationSpecification(elicitationAnnotation.clientId(), methodCallback);
 				})
 				.toList())
 			.flatMap(List::stream)
@@ -109,7 +110,7 @@ public class AsyncMcpElicitationProvider {
 			throw new IllegalStateException("Multiple elicitation methods found: " + elicitationHandlers.size());
 		}
 
-		return elicitationHandlers.get(0);
+		return elicitationHandlers;
 	}
 
 	/**

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/AsyncMcpLoggingConsumerProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/AsyncMcpLoggingConsumerProvider.java
@@ -22,7 +22,9 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.springaicommunity.mcp.annotation.McpLoggingConsumer;
+import org.springaicommunity.mcp.method.logging.AsyncLoggingSpecification;
 import org.springaicommunity.mcp.method.logging.AsyncMcpLoggingConsumerMethodCallback;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
 
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 import io.modelcontextprotocol.util.Assert;
@@ -75,9 +77,9 @@ public class AsyncMcpLoggingConsumerProvider {
 	 * Get the list of logging consumer callbacks.
 	 * @return the list of logging consumer callbacks
 	 */
-	public List<Function<LoggingMessageNotification, Mono<Void>>> getLoggingConsumers() {
+	public List<AsyncLoggingSpecification> getLoggingSpecifications() {
 
-		List<Function<LoggingMessageNotification, Mono<Void>>> loggingConsumers = this.loggingConsumerObjects.stream()
+		List<AsyncLoggingSpecification> loggingConsumers = this.loggingConsumerObjects.stream()
 			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
 				.filter(method -> method.isAnnotationPresent(McpLoggingConsumer.class))
 				.map(mcpLoggingConsumerMethod -> {
@@ -90,7 +92,7 @@ public class AsyncMcpLoggingConsumerProvider {
 						.loggingConsumer(loggingConsumerAnnotation)
 						.build();
 
-					return methodCallback;
+					return new AsyncLoggingSpecification(loggingConsumerAnnotation.clientId(), methodCallback);
 				})
 				.toList())
 			.flatMap(List::stream)

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/SyncMcpElicitationProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/SyncMcpElicitationProvider.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
 import org.springaicommunity.mcp.method.elicitation.SyncMcpElicitationMethodCallback;
 
 import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
@@ -73,13 +74,13 @@ public class SyncMcpElicitationProvider {
 	}
 
 	/**
-	 * Get the elicitation handler.
-	 * @return the elicitation handler
+	 * Get the elicitation specifications.
+	 * @return the elicitation specifications
 	 * @throws IllegalStateException if no elicitation methods are found or if multiple
 	 * elicitation methods are found
 	 */
-	public Function<ElicitRequest, ElicitResult> getElicitationHandler() {
-		List<Function<ElicitRequest, ElicitResult>> elicitationHandlers = this.elicitationObjects.stream()
+	public List<SyncElicitationSpecification> getElicitationSpecifications() {
+		List<SyncElicitationSpecification> elicitationHandlers = this.elicitationObjects.stream()
 			.map(elicitationObject -> Stream.of(doGetClassMethods(elicitationObject))
 				.filter(method -> method.isAnnotationPresent(McpElicitation.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
@@ -95,7 +96,7 @@ public class SyncMcpElicitationProvider {
 						.elicitation(elicitationAnnotation)
 						.build();
 
-					return methodCallback;
+					return new SyncElicitationSpecification(elicitationAnnotation.clientId(), methodCallback);
 				})
 				.toList())
 			.flatMap(List::stream)
@@ -108,7 +109,7 @@ public class SyncMcpElicitationProvider {
 			throw new IllegalStateException("Multiple elicitation methods found: " + elicitationHandlers.size());
 		}
 
-		return elicitationHandlers.get(0);
+		return elicitationHandlers;
 	}
 
 	/**

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/SyncMcpLoggingConsumerProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/SyncMcpLoggingConsumerProvider.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.springaicommunity.mcp.annotation.McpLoggingConsumer;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
 import org.springaicommunity.mcp.method.logging.SyncMcpLoggingConsumerMethodCallback;
 
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
@@ -74,9 +75,9 @@ public class SyncMcpLoggingConsumerProvider {
 	 * Get the list of logging consumer callbacks.
 	 * @return the list of logging consumer callbacks
 	 */
-	public List<Consumer<LoggingMessageNotification>> getLoggingConsumers() {
+	public List<SyncLoggingSpecification> getLoggingSpecifications() {
 
-		List<Consumer<LoggingMessageNotification>> loggingConsumers = this.loggingConsumerObjects.stream()
+		List<SyncLoggingSpecification> loggingConsumers = this.loggingConsumerObjects.stream()
 			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
 				.filter(method -> method.isAnnotationPresent(McpLoggingConsumer.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
@@ -89,7 +90,7 @@ public class SyncMcpLoggingConsumerProvider {
 						.loggingConsumer(loggingConsumerAnnotation)
 						.build();
 
-					return methodCallback;
+					return new SyncLoggingSpecification(loggingConsumerAnnotation.clientId(), methodCallback);
 				})
 				.toList())
 			.flatMap(List::stream)

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/AsyncMcpElicitationProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/AsyncMcpElicitationProviderTests.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.method.elicitation.AsyncElicitationSpecification;
 
 import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
 import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
@@ -30,7 +31,9 @@ public class AsyncMcpElicitationProviderTests {
 	@Test
 	public void testGetElicitationHandler() {
 		var provider = new AsyncMcpElicitationProvider(List.of(new TestElicitationHandler()));
-		Function<ElicitRequest, Mono<ElicitResult>> handler = provider.getElicitationHandler();
+
+		AsyncElicitationSpecification specification = provider.getElicitationSpecifications().get(0);
+		Function<ElicitRequest, Mono<ElicitResult>> handler = specification.elicitationHandler();
 
 		assertNotNull(handler);
 
@@ -48,7 +51,8 @@ public class AsyncMcpElicitationProviderTests {
 	@Test
 	public void testGetElicitationHandlerWithSyncMethod() {
 		var provider = new AsyncMcpElicitationProvider(List.of(new SyncElicitationHandler()));
-		Function<ElicitRequest, Mono<ElicitResult>> handler = provider.getElicitationHandler();
+		AsyncElicitationSpecification specification = provider.getElicitationSpecifications().get(0);
+		Function<ElicitRequest, Mono<ElicitResult>> handler = specification.elicitationHandler();
 
 		assertNotNull(handler);
 
@@ -67,7 +71,7 @@ public class AsyncMcpElicitationProviderTests {
 	public void testNoElicitationMethods() {
 		var provider = new AsyncMcpElicitationProvider(List.of(new Object()));
 
-		assertThrows(IllegalStateException.class, () -> provider.getElicitationHandler(),
+		assertThrows(IllegalStateException.class, () -> provider.getElicitationSpecifications(),
 				"No elicitation methods found");
 	}
 
@@ -75,7 +79,7 @@ public class AsyncMcpElicitationProviderTests {
 	public void testMultipleElicitationMethods() {
 		var provider = new AsyncMcpElicitationProvider(List.of(new MultipleElicitationHandler()));
 
-		assertThrows(IllegalStateException.class, () -> provider.getElicitationHandler(),
+		assertThrows(IllegalStateException.class, () -> provider.getElicitationSpecifications(),
 				"Multiple elicitation methods found");
 	}
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/AsyncMcpLoggingConsumerProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/AsyncMcpLoggingConsumerProviderTests.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpLoggingConsumer;
-import org.springaicommunity.mcp.provider.AsyncMcpLoggingConsumerProvider;
+import org.springaicommunity.mcp.method.logging.AsyncLoggingSpecification;
 
 import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
@@ -71,7 +71,10 @@ public class AsyncMcpLoggingConsumerProviderTests {
 		AsyncLoggingHandler loggingHandler = new AsyncLoggingHandler();
 		AsyncMcpLoggingConsumerProvider provider = new AsyncMcpLoggingConsumerProvider(List.of(loggingHandler));
 
-		List<Function<LoggingMessageNotification, Mono<Void>>> consumers = provider.getLoggingConsumers();
+		List<AsyncLoggingSpecification> specifications = provider.getLoggingSpecifications();
+		List<Function<LoggingMessageNotification, Mono<Void>>> consumers = specifications.stream()
+			.map(AsyncLoggingSpecification::loggingHandler)
+			.toList();
 
 		// Should find 3 annotated methods
 		assertThat(consumers).hasSize(3);
@@ -107,7 +110,11 @@ public class AsyncMcpLoggingConsumerProviderTests {
 	void testEmptyList() {
 		AsyncMcpLoggingConsumerProvider provider = new AsyncMcpLoggingConsumerProvider(List.of());
 
-		List<Function<LoggingMessageNotification, Mono<Void>>> consumers = provider.getLoggingConsumers();
+		List<AsyncLoggingSpecification> specifications = provider.getLoggingSpecifications();
+
+		List<Function<LoggingMessageNotification, Mono<Void>>> consumers = specifications.stream()
+			.map(AsyncLoggingSpecification::loggingHandler)
+			.toList();
 
 		assertThat(consumers).isEmpty();
 	}
@@ -118,7 +125,11 @@ public class AsyncMcpLoggingConsumerProviderTests {
 		AsyncLoggingHandler handler2 = new AsyncLoggingHandler();
 		AsyncMcpLoggingConsumerProvider provider = new AsyncMcpLoggingConsumerProvider(List.of(handler1, handler2));
 
-		List<Function<LoggingMessageNotification, Mono<Void>>> consumers = provider.getLoggingConsumers();
+		List<AsyncLoggingSpecification> specifications = provider.getLoggingSpecifications();
+
+		List<Function<LoggingMessageNotification, Mono<Void>>> consumers = specifications.stream()
+			.map(AsyncLoggingSpecification::loggingHandler)
+			.toList();
 
 		// Should find 6 annotated methods (3 from each handler)
 		assertThat(consumers).hasSize(6);

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/AsyncMcpSamplingProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/AsyncMcpSamplingProviderTests.java
@@ -14,8 +14,8 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpSampling;
 import org.springaicommunity.mcp.method.sampling.AsyncMcpSamplingMethodCallbackExample;
+import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
 import org.springaicommunity.mcp.method.sampling.SamlingTestHelper;
-import org.springaicommunity.mcp.provider.AsyncMcpSamplingProvider;
 
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
@@ -49,7 +49,9 @@ public class AsyncMcpSamplingProviderTests {
 		SingleValidMethod example = new SingleValidMethod();
 		AsyncMcpSamplingProvider provider = new AsyncMcpSamplingProvider(List.of(example));
 
-		Function<CreateMessageRequest, Mono<CreateMessageResult>> handler = provider.getSamplingHandler();
+		List<AsyncSamplingSpecification> samplingSpecs = provider.getSamplingSpecifictions();
+
+		Function<CreateMessageRequest, Mono<CreateMessageResult>> handler = samplingSpecs.get(0).samplingHandler();
 
 		assertThat(handler).isNotNull();
 
@@ -74,7 +76,7 @@ public class AsyncMcpSamplingProviderTests {
 	void testEmptySamplingObjects() {
 		AsyncMcpSamplingProvider provider = new AsyncMcpSamplingProvider(Collections.emptyList());
 
-		assertThatThrownBy(() -> provider.getSamplingHandler()).isInstanceOf(IllegalStateException.class)
+		assertThatThrownBy(() -> provider.getSamplingSpecifictions()).isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("No sampling methods found");
 	}
 
@@ -96,7 +98,7 @@ public class AsyncMcpSamplingProviderTests {
 			}
 		};
 
-		assertThatThrownBy(() -> provider.getSamplingHandler()).isInstanceOf(IllegalStateException.class)
+		assertThatThrownBy(() -> provider.getSamplingSpecifictions()).isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("Multiple sampling methods found");
 	}
 
@@ -119,7 +121,9 @@ public class AsyncMcpSamplingProviderTests {
 		DirectResultOnly example = new DirectResultOnly();
 		AsyncMcpSamplingProvider provider = new AsyncMcpSamplingProvider(List.of(example));
 
-		Function<CreateMessageRequest, Mono<CreateMessageResult>> handler = provider.getSamplingHandler();
+		List<AsyncSamplingSpecification> samplingSpecs = provider.getSamplingSpecifictions();
+
+		Function<CreateMessageRequest, Mono<CreateMessageResult>> handler = samplingSpecs.get(0).samplingHandler();
 
 		assertThat(handler).isNotNull();
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/SyncMcpElicitationProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/SyncMcpElicitationProviderTests.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
 
 import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
 import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
@@ -28,7 +29,8 @@ public class SyncMcpElicitationProviderTests {
 	@Test
 	public void testGetElicitationHandler() {
 		var provider = new SyncMcpElicitationProvider(List.of(new TestElicitationHandler()));
-		Function<ElicitRequest, ElicitResult> handler = provider.getElicitationHandler();
+		SyncElicitationSpecification specification = provider.getElicitationSpecifications().get(0);
+		Function<ElicitRequest, ElicitResult> handler = specification.elicitationHandler();
 
 		assertNotNull(handler);
 
@@ -46,7 +48,7 @@ public class SyncMcpElicitationProviderTests {
 	public void testNoElicitationMethods() {
 		var provider = new SyncMcpElicitationProvider(List.of(new Object()));
 
-		assertThrows(IllegalStateException.class, () -> provider.getElicitationHandler(),
+		assertThrows(IllegalStateException.class, () -> provider.getElicitationSpecifications(),
 				"No elicitation methods found");
 	}
 
@@ -54,7 +56,7 @@ public class SyncMcpElicitationProviderTests {
 	public void testMultipleElicitationMethods() {
 		var provider = new SyncMcpElicitationProvider(List.of(new MultipleElicitationHandler()));
 
-		assertThrows(IllegalStateException.class, () -> provider.getElicitationHandler(),
+		assertThrows(IllegalStateException.class, () -> provider.getElicitationSpecifications(),
 				"Multiple elicitation methods found");
 	}
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/SyncMcpLoggingConsumerProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/SyncMcpLoggingConsumerProviderTests.java
@@ -11,7 +11,7 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpLoggingConsumer;
-import org.springaicommunity.mcp.provider.SyncMcpLoggingConsumerProvider;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
 
 import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
@@ -60,7 +60,10 @@ public class SyncMcpLoggingConsumerProviderTests {
 		LoggingHandler loggingHandler = new LoggingHandler();
 		SyncMcpLoggingConsumerProvider provider = new SyncMcpLoggingConsumerProvider(List.of(loggingHandler));
 
-		List<Consumer<LoggingMessageNotification>> consumers = provider.getLoggingConsumers();
+		List<SyncLoggingSpecification> specifications = provider.getLoggingSpecifications();
+		List<Consumer<LoggingMessageNotification>> consumers = specifications.stream()
+			.map(SyncLoggingSpecification::loggingHandler)
+			.toList();
 
 		// Should find 2 annotated methods
 		assertThat(consumers).hasSize(2);
@@ -86,7 +89,10 @@ public class SyncMcpLoggingConsumerProviderTests {
 	void testEmptyList() {
 		SyncMcpLoggingConsumerProvider provider = new SyncMcpLoggingConsumerProvider(List.of());
 
-		List<Consumer<LoggingMessageNotification>> consumers = provider.getLoggingConsumers();
+		List<Consumer<LoggingMessageNotification>> consumers = provider.getLoggingSpecifications()
+			.stream()
+			.map(SyncLoggingSpecification::loggingHandler)
+			.toList();
 
 		assertThat(consumers).isEmpty();
 	}
@@ -97,7 +103,10 @@ public class SyncMcpLoggingConsumerProviderTests {
 		LoggingHandler handler2 = new LoggingHandler();
 		SyncMcpLoggingConsumerProvider provider = new SyncMcpLoggingConsumerProvider(List.of(handler1, handler2));
 
-		List<Consumer<LoggingMessageNotification>> consumers = provider.getLoggingConsumers();
+		List<Consumer<LoggingMessageNotification>> consumers = provider.getLoggingSpecifications()
+			.stream()
+			.map(SyncLoggingSpecification::loggingHandler)
+			.toList();
 
 		// Should find 4 annotated methods (2 from each handler)
 		assertThat(consumers).hasSize(4);

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/SyncMcpSamplingProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/SyncMcpSamplingProviderTests.java
@@ -14,8 +14,7 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpSampling;
 import org.springaicommunity.mcp.method.sampling.SamlingTestHelper;
-import org.springaicommunity.mcp.method.sampling.SyncMcpSamplingMethodCallbackExample;
-import org.springaicommunity.mcp.provider.SyncMcpSamplingProvider;
+import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
 
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
@@ -47,7 +46,9 @@ public class SyncMcpSamplingProviderTests {
 		SingleValidMethod example = new SingleValidMethod();
 		SyncMcpSamplingProvider provider = new SyncMcpSamplingProvider(List.of(example));
 
-		Function<CreateMessageRequest, CreateMessageResult> handler = provider.getSamplingHandler();
+		List<SyncSamplingSpecification> samplingSpecs = provider.getSamplingSpecifications();
+
+		Function<CreateMessageRequest, CreateMessageResult> handler = samplingSpecs.get(0).samplingHandler();
 
 		assertThat(handler).isNotNull();
 
@@ -69,7 +70,7 @@ public class SyncMcpSamplingProviderTests {
 	void testEmptySamplingObjects() {
 		SyncMcpSamplingProvider provider = new SyncMcpSamplingProvider(Collections.emptyList());
 
-		assertThatThrownBy(() -> provider.getSamplingHandler()).isInstanceOf(IllegalStateException.class)
+		assertThatThrownBy(() -> provider.getSamplingSpecifications()).isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("No sampling methods found");
 	}
 
@@ -101,7 +102,7 @@ public class SyncMcpSamplingProviderTests {
 		MultipleSamplingMethods example = new MultipleSamplingMethods();
 		SyncMcpSamplingProvider provider = new SyncMcpSamplingProvider(List.of(example));
 
-		assertThatThrownBy(() -> provider.getSamplingHandler()).isInstanceOf(IllegalStateException.class)
+		assertThatThrownBy(() -> provider.getSamplingSpecifications()).isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("Multiple sampling methods found");
 	}
 


### PR DESCRIPTION
- Add clientId parameter to @McpElicitation, @McpLoggingConsumer, and @McpSampling annotations
- Refactor providers to return specification lists instead of single handlers/consumers
- Introduce AsyncElicitationSpecification, SyncElicitationSpecification, AsyncLoggingSpecification, SyncLoggingSpecification, AsyncSamplingSpecification, and SyncSamplingSpecification classes
- Update Spring integration to use specification-based approach
- Update all provider method names from Handler/Consumer to Specifications

BREAKING CHANGE: Provider APIs now return specification lists instead of single handlers/consumers