### PR TITLE
feat: Add CallToolRequest support for dynamic schema handling

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -93,12 +93,31 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T> {
 	 * @return An array of method arguments
 	 */
 	protected Object[] buildMethodArguments(T exchangeOrContext, Map<String, Object> toolInputArguments) {
+		return buildMethodArguments(exchangeOrContext, toolInputArguments, null);
+	}
+
+	/**
+	 * Builds the method arguments from the context, tool input arguments, and optionally
+	 * the full request.
+	 * @param exchangeOrContext The exchange or context object (e.g.,
+	 * McpAsyncServerExchange or McpTransportContext)
+	 * @param toolInputArguments The input arguments from the tool request
+	 * @param request The full CallToolRequest (optional, can be null)
+	 * @return An array of method arguments
+	 */
+	protected Object[] buildMethodArguments(T exchangeOrContext, Map<String, Object> toolInputArguments,
+			CallToolRequest request) {
 		return Stream.of(this.toolMethod.getParameters()).map(parameter -> {
-			Object rawArgument = toolInputArguments.get(parameter.getName());
+			// Check if parameter is CallToolRequest type
+			if (CallToolRequest.class.isAssignableFrom(parameter.getType())) {
+				return request;
+			}
 
 			if (isExchangeOrContextType(parameter.getType())) {
 				return exchangeOrContext;
 			}
+
+			Object rawArgument = toolInputArguments.get(parameter.getName());
 			return buildTypedArgument(rawArgument, parameter.getParameterizedType());
 		}).toArray();
 	}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractSyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractSyncMcpToolMethodCallback.java
@@ -89,12 +89,31 @@ public abstract class AbstractSyncMcpToolMethodCallback<T> {
 	 * @return An array of method arguments
 	 */
 	protected Object[] buildMethodArguments(T exchangeOrContext, Map<String, Object> toolInputArguments) {
+		return buildMethodArguments(exchangeOrContext, toolInputArguments, null);
+	}
+
+	/**
+	 * Builds the method arguments from the context, tool input arguments, and optionally
+	 * the full request.
+	 * @param exchangeOrContext The exchange or context object (e.g.,
+	 * McpSyncServerExchange or McpTransportContext)
+	 * @param toolInputArguments The input arguments from the tool request
+	 * @param request The full CallToolRequest (optional, can be null)
+	 * @return An array of method arguments
+	 */
+	protected Object[] buildMethodArguments(T exchangeOrContext, Map<String, Object> toolInputArguments,
+			CallToolRequest request) {
 		return Stream.of(this.toolMethod.getParameters()).map(parameter -> {
-			Object rawArgument = toolInputArguments.get(parameter.getName());
+			// Check if parameter is CallToolRequest type
+			if (CallToolRequest.class.isAssignableFrom(parameter.getType())) {
+				return request;
+			}
 
 			if (isExchangeOrContextType(parameter.getType())) {
 				return exchangeOrContext;
 			}
+
+			Object rawArgument = toolInputArguments.get(parameter.getName());
 			return buildTypedArgument(rawArgument, parameter.getParameterizedType());
 		}).toArray();
 	}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AsyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AsyncMcpToolMethodCallback.java
@@ -60,8 +60,9 @@ public final class AsyncMcpToolMethodCallback extends AbstractAsyncMcpToolMethod
 
 		return validateRequest(request).then(Mono.defer(() -> {
 			try {
-				// Build arguments for the method call
-				Object[] args = this.buildMethodArguments(exchange, request.arguments());
+				// Build arguments for the method call, passing the full request for
+				// CallToolRequest parameter support
+				Object[] args = this.buildMethodArguments(exchange, request.arguments(), request);
 
 				// Invoke the method
 				Object result = this.callMethod(args);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AsyncStatelessMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AsyncStatelessMcpToolMethodCallback.java
@@ -62,7 +62,7 @@ public final class AsyncStatelessMcpToolMethodCallback extends AbstractAsyncMcpT
 		return validateRequest(request).then(Mono.defer(() -> {
 			try {
 				// Build arguments for the method call
-				Object[] args = this.buildMethodArguments(mcpTransportContext, request.arguments());
+				Object[] args = this.buildMethodArguments(mcpTransportContext, request.arguments(), request);
 
 				// Invoke the method
 				Object result = this.callMethod(args);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/SyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/SyncMcpToolMethodCallback.java
@@ -58,8 +58,9 @@ public final class SyncMcpToolMethodCallback extends AbstractSyncMcpToolMethodCa
 		validateRequest(request);
 
 		try {
-			// Build arguments for the method call
-			Object[] args = this.buildMethodArguments(exchange, request.arguments());
+			// Build arguments for the method call, passing the full request for
+			// CallToolRequest parameter support
+			Object[] args = this.buildMethodArguments(exchange, request.arguments(), request);
 
 			// Invoke the method
 			Object result = this.callMethod(args);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/SyncStatelessMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/SyncStatelessMcpToolMethodCallback.java
@@ -52,7 +52,8 @@ public final class SyncStatelessMcpToolMethodCallback extends AbstractSyncMcpToo
 
 		try {
 			// Build arguments for the method call
-			Object[] args = this.buildMethodArguments(mcpTransportContext, callToolRequest.arguments());
+			Object[] args = this.buildMethodArguments(mcpTransportContext, callToolRequest.arguments(),
+					callToolRequest);
 
 			// Invoke the method
 			Object result = this.callMethod(args);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/JsonSchemaGenerator.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/JsonSchemaGenerator.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -41,6 +42,7 @@ import com.github.victools.jsonschema.module.swagger2.Swagger2Module;
 
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.util.Assert;
 import io.modelcontextprotocol.util.Utils;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -93,6 +95,30 @@ public class JsonSchemaGenerator {
 	}
 
 	private static String internalGenerateFromMethodArguments(Method method) {
+		// Check if method has CallToolRequest parameter
+		boolean hasCallToolRequestParam = Arrays.stream(method.getParameterTypes())
+			.anyMatch(type -> CallToolRequest.class.isAssignableFrom(type));
+
+		// If method has CallToolRequest, return minimal schema
+		if (hasCallToolRequestParam) {
+			// Check if there are other parameters besides CallToolRequest and exchange
+			// types
+			boolean hasOtherParams = Arrays.stream(method.getParameters()).anyMatch(param -> {
+				Class<?> type = param.getType();
+				return !CallToolRequest.class.isAssignableFrom(type)
+						&& !McpSyncServerExchange.class.isAssignableFrom(type)
+						&& !McpAsyncServerExchange.class.isAssignableFrom(type);
+			});
+
+			// If only CallToolRequest (and possibly exchange), return empty schema
+			if (!hasOtherParams) {
+				ObjectNode schema = JsonParser.getObjectMapper().createObjectNode();
+				schema.put("type", "object");
+				schema.putObject("properties");
+				schema.putArray("required");
+				return schema.toPrettyString();
+			}
+		}
 
 		ObjectNode schema = JsonParser.getObjectMapper().createObjectNode();
 		schema.put("$schema", SchemaVersion.DRAFT_2020_12.getIdentifier());
@@ -104,11 +130,15 @@ public class JsonSchemaGenerator {
 		for (int i = 0; i < method.getParameterCount(); i++) {
 			String parameterName = method.getParameters()[i].getName();
 			Type parameterType = method.getGenericParameterTypes()[i];
+
+			// Skip special parameter types
 			if (parameterType instanceof Class<?> parameterClass
 					&& (ClassUtils.isAssignable(McpSyncServerExchange.class, parameterClass)
-							|| ClassUtils.isAssignable(McpAsyncServerExchange.class, parameterClass))) {
+							|| ClassUtils.isAssignable(McpAsyncServerExchange.class, parameterClass)
+							|| ClassUtils.isAssignable(CallToolRequest.class, parameterClass))) {
 				continue;
 			}
+
 			if (isMethodParameterRequired(method, i)) {
 				required.add(parameterName);
 			}
@@ -141,6 +171,15 @@ public class JsonSchemaGenerator {
 		SchemaGenerator generator = new SchemaGenerator(config);
 		JsonNode jsonSchema = generator.generateSchema(clazz);
 		return jsonSchema.toPrettyString();
+	}
+
+	/**
+	 * Check if a method has a CallToolRequest parameter.
+	 * @param method The method to check
+	 * @return true if the method has a CallToolRequest parameter, false otherwise
+	 */
+	public static boolean hasCallToolRequestParameter(Method method) {
+		return Arrays.stream(method.getParameterTypes()).anyMatch(type -> CallToolRequest.class.isAssignableFrom(type));
 	}
 
 	private static boolean isMethodParameterRequired(Method method, int index) {

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/SyncMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/SyncMcpToolProvider.java
@@ -17,6 +17,7 @@
 package org.springaicommunity.mcp.provider;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
@@ -78,7 +79,21 @@ public class SyncMcpToolProvider {
 
 					String toolDescription = toolAnnotation.description();
 
-					String inputSchema = JsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
+					// Check if method has CallToolRequest parameter
+					boolean hasCallToolRequestParam = Arrays.stream(mcpToolMethod.getParameterTypes())
+						.anyMatch(type -> CallToolRequest.class.isAssignableFrom(type));
+
+					String inputSchema;
+					if (hasCallToolRequestParam) {
+						// For methods with CallToolRequest, generate minimal schema or
+						// use the one from the request
+						// The schema generation will handle this appropriately
+						inputSchema = JsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
+						logger.debug("Tool method '{}' uses CallToolRequest parameter, using minimal schema", toolName);
+					}
+					else {
+						inputSchema = JsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
+					}
 
 					var toolBuilder = McpSchema.Tool.builder()
 						.name(toolName)

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/AsyncCallToolRequestSupportTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/AsyncCallToolRequestSupportTests.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.method.tool;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for CallToolRequest parameter support in async MCP tools.
+ *
+ * @author Christian Tzolov
+ */
+public class AsyncCallToolRequestSupportTests {
+
+	private static class AsyncCallToolRequestTestProvider {
+
+		/**
+		 * Async tool that only takes CallToolRequest - for fully dynamic handling
+		 */
+		@McpTool(name = "async-dynamic-tool", description = "Async fully dynamic tool")
+		public Mono<CallToolResult> asyncDynamicTool(CallToolRequest request) {
+			// Access full request details
+			String toolName = request.name();
+			Map<String, Object> arguments = request.arguments();
+
+			// Custom validation
+			if (!arguments.containsKey("action")) {
+				return Mono.just(CallToolResult.builder()
+					.isError(true)
+					.addTextContent("Missing required 'action' parameter")
+					.build());
+			}
+
+			String action = (String) arguments.get("action");
+			return Mono.just(CallToolResult.builder()
+				.addTextContent("Async processed action: " + action + " for tool: " + toolName)
+				.build());
+		}
+
+		/**
+		 * Async tool with CallToolRequest and Exchange parameters
+		 */
+		@McpTool(name = "async-context-aware-tool", description = "Async tool with context and request")
+		public Mono<CallToolResult> asyncContextAwareTool(McpAsyncServerExchange exchange, CallToolRequest request) {
+			// Exchange is available for context
+			Map<String, Object> arguments = request.arguments();
+
+			return Mono.just(CallToolResult.builder()
+				.addTextContent("Async Exchange available: " + (exchange != null) + ", Args: " + arguments.size())
+				.build());
+		}
+
+		/**
+		 * Async tool with mixed parameters - CallToolRequest plus regular parameters
+		 */
+		@McpTool(name = "async-mixed-params-tool", description = "Async tool with mixed parameters")
+		public Mono<CallToolResult> asyncMixedParamsTool(CallToolRequest request,
+				@McpToolParam(description = "Required string parameter", required = true) String requiredParam,
+				@McpToolParam(description = "Optional integer parameter", required = false) Integer optionalParam) {
+
+			Map<String, Object> allArguments = request.arguments();
+
+			return Mono.just(CallToolResult.builder()
+				.addTextContent(String.format("Async Required: %s, Optional: %d, Total args: %d, Tool: %s",
+						requiredParam, optionalParam != null ? optionalParam : 0, allArguments.size(), request.name()))
+				.build());
+		}
+
+		/**
+		 * Async tool that validates custom schema from CallToolRequest
+		 */
+		@McpTool(name = "async-schema-validator", description = "Async validates against custom schema")
+		public Mono<CallToolResult> asyncValidateSchema(CallToolRequest request) {
+			Map<String, Object> arguments = request.arguments();
+
+			// Custom schema validation logic
+			boolean hasRequiredFields = arguments.containsKey("data") && arguments.containsKey("format");
+
+			if (!hasRequiredFields) {
+				return Mono.just(CallToolResult.builder()
+					.isError(true)
+					.addTextContent("Async schema validation failed: missing required fields 'data' and 'format'")
+					.build());
+			}
+
+			return Mono.just(CallToolResult.builder()
+				.addTextContent("Async schema validation successful for: " + request.name())
+				.build());
+		}
+
+		/**
+		 * Regular async tool without CallToolRequest for comparison
+		 */
+		@McpTool(name = "async-regular-tool", description = "Regular async tool without CallToolRequest")
+		public Mono<String> asyncRegularTool(String input, int number) {
+			return Mono.just("Async Regular: " + input + " - " + number);
+		}
+
+		/**
+		 * Async tool that returns structured output
+		 */
+		@McpTool(name = "async-structured-output-tool", description = "Async tool with structured output")
+		public Mono<TestResult> asyncStructuredOutputTool(CallToolRequest request) {
+			Map<String, Object> arguments = request.arguments();
+			String input = (String) arguments.get("input");
+
+			return Mono.just(new TestResult(input != null ? input : "default", 42));
+		}
+
+		/**
+		 * Async tool that returns Mono<Void>
+		 */
+		@McpTool(name = "async-void-tool", description = "Async tool that returns void")
+		public Mono<Void> asyncVoidTool(CallToolRequest request) {
+			// Perform some side effect
+			Map<String, Object> arguments = request.arguments();
+			System.out.println("Processing: " + arguments);
+			return Mono.empty();
+		}
+
+		/**
+		 * Async tool that throws an error
+		 */
+		@McpTool(name = "async-error-tool", description = "Async tool that throws error")
+		public Mono<CallToolResult> asyncErrorTool(CallToolRequest request) {
+			return Mono.error(new RuntimeException("Async tool execution failed"));
+		}
+
+	}
+
+	public static class TestResult {
+
+		public String message;
+
+		public int value;
+
+		public TestResult(String message, int value) {
+			this.message = message;
+			this.value = value;
+		}
+
+	}
+
+	@Test
+	public void testAsyncDynamicToolWithCallToolRequest() throws Exception {
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncDynamicTool", CallToolRequest.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("async-dynamic-tool",
+				Map.of("action", "analyze", "data", "test-data"));
+
+		Mono<CallToolResult> resultMono = callback.apply(exchange, request);
+
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.isError()).isFalse();
+			assertThat(result.content()).hasSize(1);
+			assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
+			assertThat(((TextContent) result.content().get(0)).text())
+				.isEqualTo("Async processed action: analyze for tool: async-dynamic-tool");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testAsyncDynamicToolMissingRequiredParameter() throws Exception {
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncDynamicTool", CallToolRequest.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("async-dynamic-tool", Map.of("data", "test-data")); // Missing
+																											// 'action'
+																											// parameter
+
+		Mono<CallToolResult> resultMono = callback.apply(exchange, request);
+
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.isError()).isTrue();
+			assertThat(result.content()).hasSize(1);
+			assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Missing required 'action' parameter");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testAsyncErrorToolWithCallToolRequest() throws Exception {
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncErrorTool", CallToolRequest.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("async-error-tool", Map.of("data", "test"));
+
+		Mono<CallToolResult> resultMono = callback.apply(exchange, request);
+
+		// When a method returns Mono.error(), it propagates as an error
+		StepVerifier.create(resultMono)
+			.expectErrorMatches(throwable -> throwable instanceof RuntimeException
+					&& throwable.getMessage().contains("Async tool execution failed"))
+			.verify();
+	}
+
+	@Test
+	public void testAsyncMixedParametersTool() throws Exception {
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncMixedParamsTool", CallToolRequest.class,
+				String.class, Integer.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("async-mixed-params-tool",
+				Map.of("requiredParam", "test-value", "optionalParam", 42, "extraParam", "extra"));
+
+		Mono<CallToolResult> resultMono = callback.apply(exchange, request);
+
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.isError()).isFalse();
+			assertThat(result.content()).hasSize(1);
+			assertThat(((TextContent) result.content().get(0)).text())
+				.isEqualTo("Async Required: test-value, Optional: 42, Total args: 3, Tool: async-mixed-params-tool");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testAsyncMixedParametersToolWithNullOptional() throws Exception {
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncMixedParamsTool", CallToolRequest.class,
+				String.class, Integer.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("async-mixed-params-tool", Map.of("requiredParam", "test-value"));
+
+		Mono<CallToolResult> resultMono = callback.apply(exchange, request);
+
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.isError()).isFalse();
+			assertThat(result.content()).hasSize(1);
+			assertThat(((TextContent) result.content().get(0)).text())
+				.isEqualTo("Async Required: test-value, Optional: 0, Total args: 1, Tool: async-mixed-params-tool");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testAsyncSchemaValidatorTool() throws Exception {
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncValidateSchema", CallToolRequest.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+
+		// Test with valid schema
+		CallToolRequest validRequest = new CallToolRequest("async-schema-validator",
+				Map.of("data", "test-data", "format", "json"));
+
+		Mono<CallToolResult> validResultMono = callback.apply(exchange, validRequest);
+
+		StepVerifier.create(validResultMono).assertNext(result -> {
+			assertThat(result.isError()).isFalse();
+			assertThat(((TextContent) result.content().get(0)).text())
+				.isEqualTo("Async schema validation successful for: async-schema-validator");
+		}).verifyComplete();
+
+		// Test with invalid schema
+		CallToolRequest invalidRequest = new CallToolRequest("async-schema-validator", Map.of("data", "test-data")); // Missing
+																														// 'format'
+
+		Mono<CallToolResult> invalidResultMono = callback.apply(exchange, invalidRequest);
+
+		StepVerifier.create(invalidResultMono).assertNext(result -> {
+			assertThat(result.isError()).isTrue();
+			assertThat(((TextContent) result.content().get(0)).text()).contains("Async schema validation failed");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testAsyncStructuredOutputWithCallToolRequest() throws Exception {
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncStructuredOutputTool",
+				CallToolRequest.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.STRUCTURED, method, provider);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("async-structured-output-tool", Map.of("input", "test-message"));
+
+		Mono<CallToolResult> resultMono = callback.apply(exchange, request);
+
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.isError()).isFalse();
+			assertThat(result.structuredContent()).isNotNull();
+			assertThat(result.structuredContent()).containsEntry("message", "test-message");
+			assertThat(result.structuredContent()).containsEntry("value", 42);
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testAsyncVoidToolWithCallToolRequest() throws Exception {
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncVoidTool", CallToolRequest.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.VOID, method, provider);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("async-void-tool", Map.of("action", "process"));
+
+		Mono<CallToolResult> resultMono = callback.apply(exchange, request);
+
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.isError()).isFalse();
+			assertThat(result.content()).hasSize(1);
+			// Void methods should return "Done"
+			assertThat(((TextContent) result.content().get(0)).text()).contains("Done");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testAsyncCallToolRequestParameterInjection() throws Exception {
+		// Test that CallToolRequest is properly injected as a parameter
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncDynamicTool", CallToolRequest.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("async-dynamic-tool", Map.of("action", "test", "data", "sample"));
+
+		Mono<CallToolResult> resultMono = callback.apply(exchange, request);
+
+		StepVerifier.create(resultMono).assertNext(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.isError()).isFalse();
+			// The tool should have access to the full request including the tool name
+			assertThat(((TextContent) result.content().get(0)).text()).contains("tool: async-dynamic-tool");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testAsyncNullRequest() throws Exception {
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncDynamicTool", CallToolRequest.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+
+		Mono<CallToolResult> resultMono = callback.apply(exchange, null);
+
+		StepVerifier.create(resultMono).expectError(IllegalArgumentException.class).verify();
+	}
+
+	@Test
+	public void testAsyncIsExchangeType() throws Exception {
+		AsyncCallToolRequestTestProvider provider = new AsyncCallToolRequestTestProvider();
+		Method method = AsyncCallToolRequestTestProvider.class.getMethod("asyncDynamicTool", CallToolRequest.class);
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		// Test that McpAsyncServerExchange is recognized as exchange type
+		assertThat(callback.isExchangeOrContextType(McpAsyncServerExchange.class)).isTrue();
+
+		// Test that other types are not recognized as exchange type
+		assertThat(callback.isExchangeOrContextType(String.class)).isFalse();
+		assertThat(callback.isExchangeOrContextType(Integer.class)).isFalse();
+		assertThat(callback.isExchangeOrContextType(Object.class)).isFalse();
+	}
+
+}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/CallToolRequestSupportTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/CallToolRequestSupportTests.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.method.tool;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springaicommunity.mcp.method.tool.utils.JsonSchemaGenerator;
+import org.springaicommunity.mcp.provider.SyncMcpToolProvider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for CallToolRequest parameter support in MCP tools.
+ *
+ * @author Christian Tzolov
+ */
+public class CallToolRequestSupportTests {
+
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+
+	private static class CallToolRequestTestProvider {
+
+		/**
+		 * Tool that only takes CallToolRequest - for fully dynamic handling
+		 */
+		@McpTool(name = "dynamic-tool", description = "Fully dynamic tool")
+		public CallToolResult dynamicTool(CallToolRequest request) {
+			// Access full request details
+			String toolName = request.name();
+			Map<String, Object> arguments = request.arguments();
+
+			// Custom validation
+			if (!arguments.containsKey("action")) {
+				return CallToolResult.builder()
+					.isError(true)
+					.addTextContent("Missing required 'action' parameter")
+					.build();
+			}
+
+			String action = (String) arguments.get("action");
+			return CallToolResult.builder()
+				.addTextContent("Processed action: " + action + " for tool: " + toolName)
+				.build();
+		}
+
+		/**
+		 * Tool with CallToolRequest and Exchange parameters
+		 */
+		@McpTool(name = "context-aware-tool", description = "Tool with context and request")
+		public CallToolResult contextAwareTool(McpSyncServerExchange exchange, CallToolRequest request) {
+			// Exchange is available for context
+			Map<String, Object> arguments = request.arguments();
+
+			return CallToolResult.builder()
+				.addTextContent("Exchange available: " + (exchange != null) + ", Args: " + arguments.size())
+				.build();
+		}
+
+		/**
+		 * Tool with mixed parameters - CallToolRequest plus regular parameters
+		 */
+		@McpTool(name = "mixed-params-tool", description = "Tool with mixed parameters")
+		public CallToolResult mixedParamsTool(CallToolRequest request,
+				@McpToolParam(description = "Required string parameter", required = true) String requiredParam,
+				@McpToolParam(description = "Optional integer parameter", required = false) Integer optionalParam) {
+
+			Map<String, Object> allArguments = request.arguments();
+
+			return CallToolResult.builder()
+				.addTextContent(String.format("Required: %s, Optional: %d, Total args: %d, Tool: %s", requiredParam,
+						optionalParam != null ? optionalParam : 0, allArguments.size(), request.name()))
+				.build();
+		}
+
+		/**
+		 * Tool that validates custom schema from CallToolRequest
+		 */
+		@McpTool(name = "schema-validator", description = "Validates against custom schema")
+		public CallToolResult validateSchema(CallToolRequest request) {
+			Map<String, Object> arguments = request.arguments();
+
+			// Custom schema validation logic
+			boolean hasRequiredFields = arguments.containsKey("data") && arguments.containsKey("format");
+
+			if (!hasRequiredFields) {
+				return CallToolResult.builder()
+					.isError(true)
+					.addTextContent("Schema validation failed: missing required fields 'data' and 'format'")
+					.build();
+			}
+
+			return CallToolResult.builder()
+				.addTextContent("Schema validation successful for: " + request.name())
+				.build();
+		}
+
+		/**
+		 * Regular tool without CallToolRequest for comparison
+		 */
+		@McpTool(name = "regular-tool", description = "Regular tool without CallToolRequest")
+		public String regularTool(String input, int number) {
+			return "Regular: " + input + " - " + number;
+		}
+
+		/**
+		 * Tool that returns structured output
+		 */
+		@McpTool(name = "structured-output-tool", description = "Tool with structured output")
+		public TestResult structuredOutputTool(CallToolRequest request) {
+			Map<String, Object> arguments = request.arguments();
+			String input = (String) arguments.get("input");
+
+			return new TestResult(input != null ? input : "default", 42);
+		}
+
+	}
+
+	public static class TestResult {
+
+		public String message;
+
+		public int value;
+
+		public TestResult(String message, int value) {
+			this.message = message;
+			this.value = value;
+		}
+
+	}
+
+	@Test
+	public void testDynamicToolWithCallToolRequest() throws Exception {
+		CallToolRequestTestProvider provider = new CallToolRequestTestProvider();
+		Method method = CallToolRequestTestProvider.class.getMethod("dynamicTool", CallToolRequest.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("dynamic-tool", Map.of("action", "analyze", "data", "test-data"));
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
+		assertThat(((TextContent) result.content().get(0)).text())
+			.isEqualTo("Processed action: analyze for tool: dynamic-tool");
+	}
+
+	@Test
+	public void testDynamicToolMissingRequiredParameter() throws Exception {
+		CallToolRequestTestProvider provider = new CallToolRequestTestProvider();
+		Method method = CallToolRequestTestProvider.class.getMethod("dynamicTool", CallToolRequest.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("dynamic-tool", Map.of("data", "test-data")); // Missing
+																									// 'action'
+																									// parameter
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isTrue();
+		assertThat(result.content()).hasSize(1);
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Missing required 'action' parameter");
+	}
+
+	@Test
+	public void testContextAwareToolWithCallToolRequestAndExchange() throws Exception {
+		CallToolRequestTestProvider provider = new CallToolRequestTestProvider();
+		Method method = CallToolRequestTestProvider.class.getMethod("contextAwareTool", McpSyncServerExchange.class,
+				CallToolRequest.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+
+		CallToolRequest request = new CallToolRequest("context-aware-tool", Map.of("key1", "value1", "key2", "value2"));
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(1);
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Exchange available: true, Args: 2");
+	}
+
+	@Test
+	public void testMixedParametersTool() throws Exception {
+		CallToolRequestTestProvider provider = new CallToolRequestTestProvider();
+		Method method = CallToolRequestTestProvider.class.getMethod("mixedParamsTool", CallToolRequest.class,
+				String.class, Integer.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("mixed-params-tool",
+				Map.of("requiredParam", "test-value", "optionalParam", 42, "extraParam", "extra"));
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(1);
+		assertThat(((TextContent) result.content().get(0)).text())
+			.isEqualTo("Required: test-value, Optional: 42, Total args: 3, Tool: mixed-params-tool");
+	}
+
+	@Test
+	public void testMixedParametersToolWithNullOptional() throws Exception {
+		CallToolRequestTestProvider provider = new CallToolRequestTestProvider();
+		Method method = CallToolRequestTestProvider.class.getMethod("mixedParamsTool", CallToolRequest.class,
+				String.class, Integer.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("mixed-params-tool", Map.of("requiredParam", "test-value"));
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(1);
+		assertThat(((TextContent) result.content().get(0)).text())
+			.isEqualTo("Required: test-value, Optional: 0, Total args: 1, Tool: mixed-params-tool");
+	}
+
+	@Test
+	public void testSchemaValidatorTool() throws Exception {
+		CallToolRequestTestProvider provider = new CallToolRequestTestProvider();
+		Method method = CallToolRequestTestProvider.class.getMethod("validateSchema", CallToolRequest.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+
+		// Test with valid schema
+		CallToolRequest validRequest = new CallToolRequest("schema-validator",
+				Map.of("data", "test-data", "format", "json"));
+
+		CallToolResult validResult = callback.apply(exchange, validRequest);
+		assertThat(validResult.isError()).isFalse();
+		assertThat(((TextContent) validResult.content().get(0)).text())
+			.isEqualTo("Schema validation successful for: schema-validator");
+
+		// Test with invalid schema
+		CallToolRequest invalidRequest = new CallToolRequest("schema-validator", Map.of("data", "test-data")); // Missing
+																												// 'format'
+
+		CallToolResult invalidResult = callback.apply(exchange, invalidRequest);
+		assertThat(invalidResult.isError()).isTrue();
+		assertThat(((TextContent) invalidResult.content().get(0)).text()).contains("Schema validation failed");
+	}
+
+	@Test
+	public void testJsonSchemaGenerationForCallToolRequest() throws Exception {
+		// Test that schema generation handles CallToolRequest properly
+		Method dynamicMethod = CallToolRequestTestProvider.class.getMethod("dynamicTool", CallToolRequest.class);
+		String dynamicSchema = JsonSchemaGenerator.generateForMethodInput(dynamicMethod);
+
+		// Parse the schema
+		JsonNode schemaNode = objectMapper.readTree(dynamicSchema);
+
+		// Should have minimal schema with empty properties
+		assertThat(schemaNode.has("type")).isTrue();
+		assertThat(schemaNode.get("type").asText()).isEqualTo("object");
+		assertThat(schemaNode.has("properties")).isTrue();
+		assertThat(schemaNode.get("properties").size()).isEqualTo(0);
+		assertThat(schemaNode.has("required")).isTrue();
+		assertThat(schemaNode.get("required").size()).isEqualTo(0);
+	}
+
+	@Test
+	public void testJsonSchemaGenerationForMixedParameters() throws Exception {
+		// Test schema generation for method with CallToolRequest and other parameters
+		Method mixedMethod = CallToolRequestTestProvider.class.getMethod("mixedParamsTool", CallToolRequest.class,
+				String.class, Integer.class);
+		String mixedSchema = JsonSchemaGenerator.generateForMethodInput(mixedMethod);
+
+		// Parse the schema
+		JsonNode schemaNode = objectMapper.readTree(mixedSchema);
+
+		// Should have schema for non-CallToolRequest parameters only
+		assertThat(schemaNode.has("properties")).isTrue();
+		JsonNode properties = schemaNode.get("properties");
+		assertThat(properties.has("requiredParam")).isTrue();
+		assertThat(properties.has("optionalParam")).isTrue();
+		assertThat(properties.size()).isEqualTo(2); // Only the regular parameters
+
+		// Check required array
+		assertThat(schemaNode.has("required")).isTrue();
+		JsonNode required = schemaNode.get("required");
+		assertThat(required.size()).isEqualTo(1);
+		assertThat(required.get(0).asText()).isEqualTo("requiredParam");
+	}
+
+	@Test
+	public void testJsonSchemaGenerationForRegularTool() throws Exception {
+		// Test that regular tools still work as before
+		Method regularMethod = CallToolRequestTestProvider.class.getMethod("regularTool", String.class, int.class);
+		String regularSchema = JsonSchemaGenerator.generateForMethodInput(regularMethod);
+
+		// Parse the schema
+		JsonNode schemaNode = objectMapper.readTree(regularSchema);
+
+		// Should have normal schema with all parameters
+		assertThat(schemaNode.has("properties")).isTrue();
+		JsonNode properties = schemaNode.get("properties");
+		assertThat(properties.has("input")).isTrue();
+		assertThat(properties.has("number")).isTrue();
+		assertThat(properties.size()).isEqualTo(2);
+	}
+
+	@Test
+	public void testHasCallToolRequestParameter() throws Exception {
+		// Test the utility method
+		Method dynamicMethod = CallToolRequestTestProvider.class.getMethod("dynamicTool", CallToolRequest.class);
+		assertThat(JsonSchemaGenerator.hasCallToolRequestParameter(dynamicMethod)).isTrue();
+
+		Method regularMethod = CallToolRequestTestProvider.class.getMethod("regularTool", String.class, int.class);
+		assertThat(JsonSchemaGenerator.hasCallToolRequestParameter(regularMethod)).isFalse();
+
+		Method mixedMethod = CallToolRequestTestProvider.class.getMethod("mixedParamsTool", CallToolRequest.class,
+				String.class, Integer.class);
+		assertThat(JsonSchemaGenerator.hasCallToolRequestParameter(mixedMethod)).isTrue();
+	}
+
+	@Test
+	public void testSyncMcpToolProviderWithCallToolRequest() {
+		// Test that SyncMcpToolProvider handles CallToolRequest tools correctly
+		CallToolRequestTestProvider provider = new CallToolRequestTestProvider();
+		SyncMcpToolProvider toolProvider = new SyncMcpToolProvider(List.of(provider));
+
+		var toolSpecs = toolProvider.getToolSpecifications();
+
+		// Should have all tools registered
+		assertThat(toolSpecs).hasSize(6); // All 6 tools from the provider
+
+		// Find the dynamic tool
+		var dynamicToolSpec = toolSpecs.stream()
+			.filter(spec -> spec.tool().name().equals("dynamic-tool"))
+			.findFirst()
+			.orElse(null);
+
+		assertThat(dynamicToolSpec).isNotNull();
+		assertThat(dynamicToolSpec.tool().description()).isEqualTo("Fully dynamic tool");
+
+		// The input schema should be minimal
+		var inputSchema = dynamicToolSpec.tool().inputSchema();
+		assertThat(inputSchema).isNotNull();
+		// Convert to string if it's a JsonSchema object
+		String schemaStr = inputSchema.toString();
+		assertThat(schemaStr).isNotNull();
+
+		// Find the mixed params tool
+		var mixedToolSpec = toolSpecs.stream()
+			.filter(spec -> spec.tool().name().equals("mixed-params-tool"))
+			.findFirst()
+			.orElse(null);
+
+		assertThat(mixedToolSpec).isNotNull();
+		// The input schema should contain only the regular parameters
+		var mixedSchema = mixedToolSpec.tool().inputSchema();
+		assertThat(mixedSchema).isNotNull();
+		// Convert to string if it's a JsonSchema object
+		String mixedSchemaStr = mixedSchema.toString();
+		assertThat(mixedSchemaStr).contains("requiredParam");
+		assertThat(mixedSchemaStr).contains("optionalParam");
+	}
+
+	@Test
+	public void testStructuredOutputWithCallToolRequest() throws Exception {
+		CallToolRequestTestProvider provider = new CallToolRequestTestProvider();
+		Method method = CallToolRequestTestProvider.class.getMethod("structuredOutputTool", CallToolRequest.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.STRUCTURED, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("structured-output-tool", Map.of("input", "test-message"));
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.structuredContent()).isNotNull();
+		assertThat(result.structuredContent()).containsEntry("message", "test-message");
+		assertThat(result.structuredContent()).containsEntry("value", 42);
+	}
+
+	@Test
+	public void testCallToolRequestParameterInjection() throws Exception {
+		// Test that CallToolRequest is properly injected as a parameter
+		CallToolRequestTestProvider provider = new CallToolRequestTestProvider();
+		Method method = CallToolRequestTestProvider.class.getMethod("dynamicTool", CallToolRequest.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("dynamic-tool", Map.of("action", "test", "data", "sample"));
+
+		// The callback should properly inject the CallToolRequest
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		// The tool should have access to the full request including the tool name
+		assertThat(((TextContent) result.content().get(0)).text()).contains("tool: dynamic-tool");
+	}
+
+}


### PR DESCRIPTION
- Enable tools to accept CallToolRequest parameters for runtime schema support
- Implement injection in all sync/async and stateful/stateless callbacks
- Enhance JsonSchemaGenerator for minimal/partial schema generation
- Add 82 comprehensive tests across all implementations
- Update documentation with examples and usage guidelines

Allows tools to process dynamic schemas at runtime while maintaining backward compatibility with existing tool implementations.