### PR TITLE
feat: Add @McpProgressToken annotation support for progress tracking

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpProgress.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpProgress.java
@@ -16,20 +16,19 @@ import java.lang.annotation.Target;
  *
  * <p>
  * Methods annotated with this annotation can be used to consume progress messages from
- * MCP servers. The methods takes a single parameter of type
- * {@code ProgressMessageNotification}
+ * MCP servers. The methods takes a single parameter of type {@code ProgressNotification}
  *
  *
  * <p>
  * Example usage: <pre>{@code
  * &#64;McpProgress
- * public void handleProgressMessage(ProgressMessageNotification notification) {
+ * public void handleProgressMessage(ProgressNotification notification) {
  *     // Handle the notification *
  * }</pre>
  *
  * @author Christian Tzolov
  *
- * @see io.modelcontextprotocol.spec.McpSchema.ProgressMessageNotification
+ * @see io.modelcontextprotocol.spec.McpSchema.ProgressNotification
  */
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpProgressToken.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpProgressToken.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to annotate method parameter that should hold the progress token value as received
+ * from the requester.
+ *
+ * @author Christian Tzolov
+ */
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface McpProgressToken {
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.reactivestreams.Publisher;
+import org.springaicommunity.mcp.annotation.McpProgressToken;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.method.tool.utils.JsonParser;
 
@@ -86,17 +87,6 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T> {
 	}
 
 	/**
-	 * Builds the method arguments from the context and tool input arguments.
-	 * @param exchangeOrContext The exchange or context object (e.g.,
-	 * McpAsyncServerExchange or McpTransportContext)
-	 * @param toolInputArguments The input arguments from the tool request
-	 * @return An array of method arguments
-	 */
-	protected Object[] buildMethodArguments(T exchangeOrContext, Map<String, Object> toolInputArguments) {
-		return buildMethodArguments(exchangeOrContext, toolInputArguments, null);
-	}
-
-	/**
 	 * Builds the method arguments from the context, tool input arguments, and optionally
 	 * the full request.
 	 * @param exchangeOrContext The exchange or context object (e.g.,
@@ -108,6 +98,12 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T> {
 	protected Object[] buildMethodArguments(T exchangeOrContext, Map<String, Object> toolInputArguments,
 			CallToolRequest request) {
 		return Stream.of(this.toolMethod.getParameters()).map(parameter -> {
+			// Check if parameter is annotated with @McpProgressToken
+			if (parameter.isAnnotationPresent(McpProgressToken.class)) {
+				// Return the progress token from the request
+				return request != null ? request.progressToken() : null;
+			}
+
 			// Check if parameter is CallToolRequest type
 			if (CallToolRequest.class.isAssignableFrom(parameter.getType())) {
 				return request;

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractSyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractSyncMcpToolMethodCallback.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.springaicommunity.mcp.annotation.McpProgressToken;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.method.tool.utils.JsonParser;
 
@@ -82,17 +83,6 @@ public abstract class AbstractSyncMcpToolMethodCallback<T> {
 	}
 
 	/**
-	 * Builds the method arguments from the context and tool input arguments.
-	 * @param exchangeOrContext The exchange or context object (e.g.,
-	 * McpSyncServerExchange or McpTransportContext)
-	 * @param toolInputArguments The input arguments from the tool request
-	 * @return An array of method arguments
-	 */
-	protected Object[] buildMethodArguments(T exchangeOrContext, Map<String, Object> toolInputArguments) {
-		return buildMethodArguments(exchangeOrContext, toolInputArguments, null);
-	}
-
-	/**
 	 * Builds the method arguments from the context, tool input arguments, and optionally
 	 * the full request.
 	 * @param exchangeOrContext The exchange or context object (e.g.,
@@ -104,6 +94,12 @@ public abstract class AbstractSyncMcpToolMethodCallback<T> {
 	protected Object[] buildMethodArguments(T exchangeOrContext, Map<String, Object> toolInputArguments,
 			CallToolRequest request) {
 		return Stream.of(this.toolMethod.getParameters()).map(parameter -> {
+			// Check if parameter is annotated with @McpProgressToken
+			if (parameter.isAnnotationPresent(McpProgressToken.class)) {
+				// Return the progress token from the request
+				return request != null ? request.progressToken() : null;
+			}
+
 			// Check if parameter is CallToolRequest type
 			if (CallToolRequest.class.isAssignableFrom(parameter.getType())) {
 				return request;


### PR DESCRIPTION
Add support for @McpProgressToken annotation across all MCP callback types to enable progress token injection for tracking long-running operations.

- Add @McpProgressToken annotation for marking progress token parameters
- Implement progress token detection and injection in AbstractSyncMcpToolMethodCallback
- Implement progress token detection and injection in AbstractAsyncMcpToolMethodCallback
- Update JsonSchemaGenerator to exclude @McpProgressToken parameters from schemas
- Add progress token support to AbstractMcpResourceMethodCallback (sync and async)
- Add progress token support to AbstractMcpPromptMethodCallback (sync and async)
- Add progress token support to AbstractMcpCompleteMethodCallback (sync and async)
- Update README.md with @McpProgressToken documentation

Parameter Handling:
- Progress token parameters are automatically injected from request.requestToken()
- Parameters annotated with @McpProgressToken are excluded from rawArguments
- Null is injected when no progress token is present in the request
- Fixed validation logic to correctly count progress token parameters separately

Testing:
- Add tests for tool callbacks with @McpProgressToken
- Add tests for resource callbacks with progress token support
- Add tests for prompt callbacks with progress token support
- Add tests for complete callbacks with progress token support