### PR TITLE
feat: add McpMeta parameter support for accessing request metadata

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpMeta.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpMeta.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.annotation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Special object used to represent the {@link McpSchema.Request#meta()},
+ * {@link McpSchema.Notification#meta()} and {@link McpSchema.Result#meta()} values as
+ * method argument in all client and server MCP request and notification handlers.
+ *
+ * @author Christian Tzolov
+ */
+public record McpMeta(Map<String, Object> meta) {
+
+	public McpMeta {
+		// Ensure idempotent initialization by creating an immutable copy
+		meta = meta == null ? Collections.emptyMap() : Collections.unmodifiableMap(new HashMap<>(meta));
+	}
+
+	public Object get(String key) {
+		return meta.get(key);
+	}
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.reactivestreams.Publisher;
+import org.springaicommunity.mcp.annotation.McpMeta;
 import org.springaicommunity.mcp.annotation.McpProgressToken;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.method.tool.utils.JsonParser;
@@ -102,6 +103,12 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T> {
 			if (parameter.isAnnotationPresent(McpProgressToken.class)) {
 				// Return the progress token from the request
 				return request != null ? request.progressToken() : null;
+			}
+
+			// Check if parameter is McpMeta type
+			if (McpMeta.class.isAssignableFrom(parameter.getType())) {
+				// Return the meta from the request wrapped in McpMeta
+				return request != null ? new McpMeta(request.meta()) : new McpMeta(null);
 			}
 
 			// Check if parameter is CallToolRequest type

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractSyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractSyncMcpToolMethodCallback.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.springaicommunity.mcp.annotation.McpMeta;
 import org.springaicommunity.mcp.annotation.McpProgressToken;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.method.tool.utils.JsonParser;
@@ -98,6 +99,12 @@ public abstract class AbstractSyncMcpToolMethodCallback<T> {
 			if (parameter.isAnnotationPresent(McpProgressToken.class)) {
 				// Return the progress token from the request
 				return request != null ? request.progressToken() : null;
+			}
+
+			// Check if parameter is McpMeta type
+			if (McpMeta.class.isAssignableFrom(parameter.getType())) {
+				// Return the meta from the request wrapped in McpMeta
+				return request != null ? new McpMeta(request.meta()) : new McpMeta(null);
 			}
 
 			// Check if parameter is CallToolRequest type

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/JsonSchemaGenerator.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/JsonSchemaGenerator.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.springaicommunity.mcp.annotation.McpMeta;
 import org.springaicommunity.mcp.annotation.McpProgressToken;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 
@@ -104,13 +105,13 @@ public class JsonSchemaGenerator {
 		if (hasCallToolRequestParam) {
 			// Check if there are other parameters besides CallToolRequest, exchange
 			// types,
-			// and @McpProgressToken annotated parameters
+			// @McpProgressToken annotated parameters, and McpMeta parameters
 			boolean hasOtherParams = Arrays.stream(method.getParameters()).anyMatch(param -> {
 				Class<?> type = param.getType();
 				return !CallToolRequest.class.isAssignableFrom(type)
 						&& !McpSyncServerExchange.class.isAssignableFrom(type)
 						&& !McpAsyncServerExchange.class.isAssignableFrom(type)
-						&& !param.isAnnotationPresent(McpProgressToken.class);
+						&& !param.isAnnotationPresent(McpProgressToken.class) && !McpMeta.class.isAssignableFrom(type);
 			});
 
 			// If only CallToolRequest (and possibly exchange), return empty schema
@@ -137,6 +138,11 @@ public class JsonSchemaGenerator {
 
 			// Skip parameters annotated with @McpProgressToken
 			if (parameter.isAnnotationPresent(McpProgressToken.class)) {
+				continue;
+			}
+
+			// Skip McpMeta parameters
+			if (parameterType instanceof Class<?> parameterClass && McpMeta.class.isAssignableFrom(parameterClass)) {
 				continue;
 			}
 


### PR DESCRIPTION
- Add McpMeta class to wrap metadata from MCP requests, notifications, and results
- Support McpMeta parameter injection in all method callback types (tools, resources, prompts, completions)
- Exclude McpMeta parameters from parameter count limits and JSON schema generation
- Enable context-aware MCP operations with client-provided metadata (user identity, preferences, session info)
- Add comprehensive test coverage for McpMeta functionality across all callback types
- Update documentation with usage examples for tools, resources, prompts, and completions

This enhancement allows MCP methods to access contextual information from clients, enabling personalized and context-aware responses based on metadata such as user roles, preferences, session data, or any other client-provided context.