### PR TITLE
feat: add @McpResourceListChanged annotation support

### DIFF
--- a/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/AsyncMcpAnnotationProvider.java
+++ b/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/AsyncMcpAnnotationProvider.java
@@ -18,11 +18,13 @@ package org.springaicommunity.mcp.spring;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import org.springaicommunity.mcp.method.changed.resource.AsyncResourceListChangedSpecification;
 import org.springaicommunity.mcp.method.changed.tool.AsyncToolListChangedSpecification;
 import org.springaicommunity.mcp.method.elicitation.AsyncElicitationSpecification;
 import org.springaicommunity.mcp.method.logging.AsyncLoggingSpecification;
 import org.springaicommunity.mcp.method.progress.AsyncProgressSpecification;
 import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
+import org.springaicommunity.mcp.provider.changed.resource.AsyncMcpResourceListChangedProvider;
 import org.springaicommunity.mcp.provider.changed.tool.AsyncMcpToolListChangedProvider;
 import org.springaicommunity.mcp.provider.elicitation.AsyncMcpElicitationProvider;
 import org.springaicommunity.mcp.provider.logging.AsyncMcpLoggingProvider;
@@ -158,6 +160,19 @@ public class AsyncMcpAnnotationProvider {
 
 	}
 
+	private static class SpringAiAsyncMcpResourceListChangedProvider extends AsyncMcpResourceListChangedProvider {
+
+		public SpringAiAsyncMcpResourceListChangedProvider(List<Object> resourceListChangedObjects) {
+			super(resourceListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
 	public static List<AsyncLoggingSpecification> createAsyncLoggingSpecifications(List<Object> loggingObjects) {
 		return new SpringAiAsyncMcpLoggingProvider(loggingObjects).getLoggingSpecifications();
 	}
@@ -197,6 +212,12 @@ public class AsyncMcpAnnotationProvider {
 	public static List<AsyncToolListChangedSpecification> createAsyncToolListChangedSpecifications(
 			List<Object> toolListChangedObjects) {
 		return new SpringAiAsyncMcpToolListChangedProvider(toolListChangedObjects).getToolListChangedSpecifications();
+	}
+
+	public static List<AsyncResourceListChangedSpecification> createAsyncResourceListChangedSpecifications(
+			List<Object> resourceListChangedObjects) {
+		return new SpringAiAsyncMcpResourceListChangedProvider(resourceListChangedObjects)
+			.getResourceListChangedSpecifications();
 	}
 
 }

--- a/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/SyncMcpAnnotationProvider.java
+++ b/mcp-annotations-spring/src/main/java/org/springaicommunity/mcp/spring/SyncMcpAnnotationProvider.java
@@ -18,11 +18,13 @@ package org.springaicommunity.mcp.spring;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import org.springaicommunity.mcp.method.changed.resource.SyncResourceListChangedSpecification;
 import org.springaicommunity.mcp.method.changed.tool.SyncToolListChangedSpecification;
 import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
 import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
 import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
 import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
+import org.springaicommunity.mcp.provider.changed.resource.SyncMcpResourceListChangedProvider;
 import org.springaicommunity.mcp.provider.changed.tool.SyncMcpToolListChangedProvider;
 import org.springaicommunity.mcp.provider.complete.SyncMcpCompletionProvider;
 import org.springaicommunity.mcp.provider.elicitation.SyncMcpElicitationProvider;
@@ -203,6 +205,19 @@ public class SyncMcpAnnotationProvider {
 
 	}
 
+	private static class SpringAiSyncMcpResourceListChangedProvider extends SyncMcpResourceListChangedProvider {
+
+		public SpringAiSyncMcpResourceListChangedProvider(List<Object> resourceListChangedObjects) {
+			super(resourceListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
 	public static List<SyncToolSpecification> createSyncToolSpecifications(List<Object> toolObjects) {
 		return new SpringAiSyncToolProvider(toolObjects).getToolSpecifications();
 	}
@@ -254,6 +269,12 @@ public class SyncMcpAnnotationProvider {
 	public static List<SyncToolListChangedSpecification> createSyncToolListChangedSpecifications(
 			List<Object> toolListChangedObjects) {
 		return new SpringAiSyncMcpToolListChangedProvider(toolListChangedObjects).getToolListChangedSpecifications();
+	}
+
+	public static List<SyncResourceListChangedSpecification> createSyncResourceListChangedSpecifications(
+			List<Object> resourceListChangedObjects) {
+		return new SpringAiSyncMcpResourceListChangedProvider(resourceListChangedObjects)
+			.getResourceListChangedSpecifications();
 	}
 
 }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpResourceListChanged.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpResourceListChanged.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for methods that handle resource list change notifications from MCP servers.
+ * This annotation is applicable only for MCP clients.
+ *
+ * <p>
+ * Methods annotated with this annotation are used to listen for notifications when the
+ * list of available resources changes on an MCP server. According to the MCP
+ * specification, servers that declare the {@code listChanged} capability will send
+ * notifications when their resource list is modified.
+ *
+ * <p>
+ * The annotated method must have a void return type for synchronous consumers, or can
+ * return {@code Mono<Void>} for asynchronous consumers. The method should accept a single
+ * parameter of type {@code List<McpSchema.Resource>} that represents the updated list of
+ * resources after the change notification.
+ *
+ * <p>
+ * Example usage: <pre>{@code
+ * &#64;McpResourceListChanged
+ * public void onResourceListChanged(List<McpSchema.Resource> updatedResources) {
+ *     // Handle resource list change notification with the updated resources
+ *     logger.info("Resource list updated, now contains {} resources", updatedResources.size());
+ *     // Process the updated resource list
+ * }
+ *
+ * &#64;McpResourceListChanged
+ * public Mono<Void> onResourceListChangedAsync(List<McpSchema.Resource> updatedResources) {
+ *     // Handle resource list change notification asynchronously
+ *     return processUpdatedResources(updatedResources);
+ * }
+ * }</pre>
+ *
+ * @author Christian Tzolov
+ * @see <a href=
+ * "https://modelcontextprotocol.io/specification/2025-06-18/server/resources#list-changed-notification">MCP
+ * Resource List Changed Notification</a>
+ */
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface McpResourceListChanged {
+
+	/**
+	 * Used as connection or client identifier to select the MCP client that the resource
+	 * change listener is associated with. If not specified, the listener is applied to
+	 * all clients and will receive notifications from any connected MCP server that
+	 * supports resource list change notifications.
+	 * @return the client identifier, or empty string to listen to all clients
+	 */
+	String clientId() default "";
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/changed/resource/AbstractMcpResourceListChangedMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/changed/resource/AbstractMcpResourceListChangedMethodCallback.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.changed.resource;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.List;
+
+import org.springaicommunity.mcp.annotation.McpResourceListChanged;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.util.Assert;
+
+/**
+ * Abstract base class for creating callbacks around resource list changed consumer
+ * methods.
+ *
+ * This class provides common functionality for both synchronous and asynchronous resource
+ * list changed consumer method callbacks. It contains shared logic for method validation,
+ * argument building, and other common operations.
+ *
+ * @author Christian Tzolov
+ */
+public abstract class AbstractMcpResourceListChangedMethodCallback {
+
+	protected final Method method;
+
+	protected final Object bean;
+
+	/**
+	 * Constructor for AbstractMcpResourceListChangedMethodCallback.
+	 * @param method The method to create a callback for
+	 * @param bean The bean instance that contains the method
+	 */
+	protected AbstractMcpResourceListChangedMethodCallback(Method method, Object bean) {
+		Assert.notNull(method, "Method can't be null!");
+		Assert.notNull(bean, "Bean can't be null!");
+
+		this.method = method;
+		this.bean = bean;
+		this.validateMethod(this.method);
+	}
+
+	/**
+	 * Validates that the method signature is compatible with the resource list changed
+	 * consumer callback.
+	 * <p>
+	 * This method checks that the return type is valid and that the parameters match the
+	 * expected pattern.
+	 * @param method The method to validate
+	 * @throws IllegalArgumentException if the method signature is not compatible
+	 */
+	protected void validateMethod(Method method) {
+		if (method == null) {
+			throw new IllegalArgumentException("Method must not be null");
+		}
+
+		this.validateReturnType(method);
+		this.validateParameters(method);
+	}
+
+	/**
+	 * Validates that the method return type is compatible with the resource list changed
+	 * consumer callback. This method should be implemented by subclasses to handle
+	 * specific return type validation.
+	 * @param method The method to validate
+	 * @throws IllegalArgumentException if the return type is not compatible
+	 */
+	protected abstract void validateReturnType(Method method);
+
+	/**
+	 * Validates method parameters. This method provides common validation logic.
+	 * @param method The method to validate
+	 * @throws IllegalArgumentException if the parameters are not compatible
+	 */
+	protected void validateParameters(Method method) {
+		Parameter[] parameters = method.getParameters();
+
+		// Check parameter count - must have exactly 1 parameter
+		if (parameters.length != 1) {
+			throw new IllegalArgumentException(
+					"Method must have exactly 1 parameter (List<McpSchema.Resource>): " + method.getName() + " in "
+							+ method.getDeclaringClass().getName() + " has " + parameters.length + " parameters");
+		}
+
+		// Check parameter type - must be List<McpSchema.Resource>
+		Class<?> paramType = parameters[0].getType();
+		if (!List.class.isAssignableFrom(paramType)) {
+			throw new IllegalArgumentException("Parameter must be of type List<McpSchema.Resource>: " + method.getName()
+					+ " in " + method.getDeclaringClass().getName() + " has parameter of type " + paramType.getName());
+		}
+	}
+
+	/**
+	 * Builds the arguments array for invoking the method.
+	 * <p>
+	 * This method constructs an array of arguments based on the method's parameter types
+	 * and the available values.
+	 * @param method The method to build arguments for
+	 * @param exchange The server exchange
+	 * @param updatedResources The updated list of resources
+	 * @return An array of arguments for the method invocation
+	 */
+	protected Object[] buildArgs(Method method, Object exchange, List<McpSchema.Resource> updatedResources) {
+		Parameter[] parameters = method.getParameters();
+		Object[] args = new Object[parameters.length];
+
+		// Single parameter (List<McpSchema.Resource>)
+		args[0] = updatedResources;
+
+		return args;
+	}
+
+	/**
+	 * Exception thrown when there is an error invoking a resource list changed consumer
+	 * method.
+	 */
+	public static class McpResourceListChangedConsumerMethodException extends RuntimeException {
+
+		private static final long serialVersionUID = 1L;
+
+		/**
+		 * Constructs a new exception with the specified detail message and cause.
+		 * @param message The detail message
+		 * @param cause The cause
+		 */
+		public McpResourceListChangedConsumerMethodException(String message, Throwable cause) {
+			super(message, cause);
+		}
+
+		/**
+		 * Constructs a new exception with the specified detail message.
+		 * @param message The detail message
+		 */
+		public McpResourceListChangedConsumerMethodException(String message) {
+			super(message);
+		}
+
+	}
+
+	/**
+	 * Abstract builder for creating McpResourceListChangedMethodCallback instances.
+	 * <p>
+	 * This builder provides a base for constructing callback instances with the required
+	 * parameters.
+	 *
+	 * @param <T> The type of the builder
+	 * @param <R> The type of the callback
+	 */
+	protected abstract static class AbstractBuilder<T extends AbstractBuilder<T, R>, R> {
+
+		protected Method method;
+
+		protected Object bean;
+
+		/**
+		 * Set the method to create a callback for.
+		 * @param method The method to create a callback for
+		 * @return This builder
+		 */
+		@SuppressWarnings("unchecked")
+		public T method(Method method) {
+			this.method = method;
+			return (T) this;
+		}
+
+		/**
+		 * Set the bean instance that contains the method.
+		 * @param bean The bean instance
+		 * @return This builder
+		 */
+		@SuppressWarnings("unchecked")
+		public T bean(Object bean) {
+			this.bean = bean;
+			return (T) this;
+		}
+
+		/**
+		 * Set the resource list changed annotation.
+		 * @param resourceListChanged The resource list changed annotation
+		 * @return This builder
+		 */
+		@SuppressWarnings("unchecked")
+		public T resourceListChanged(McpResourceListChanged resourceListChanged) {
+			// No additional configuration needed from the annotation at this time
+			return (T) this;
+		}
+
+		/**
+		 * Validate the builder state.
+		 * @throws IllegalArgumentException if the builder state is invalid
+		 */
+		protected void validate() {
+			if (method == null) {
+				throw new IllegalArgumentException("Method must not be null");
+			}
+			if (bean == null) {
+				throw new IllegalArgumentException("Bean must not be null");
+			}
+		}
+
+		/**
+		 * Build the callback.
+		 * @return A new callback instance
+		 */
+		public abstract R build();
+
+	}
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/changed/resource/AsyncMcpResourceListChangedMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/changed/resource/AsyncMcpResourceListChangedMethodCallback.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.changed.resource;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Function;
+
+import org.springaicommunity.mcp.annotation.McpResourceListChanged;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+
+/**
+ * Class for creating Function callbacks around resource list changed consumer methods
+ * that return Mono.
+ *
+ * This class provides a way to convert methods annotated with
+ * {@link McpResourceListChanged} into callback functions that can be used to handle
+ * resource list change notifications in a reactive way. It supports methods with a single
+ * List&lt;McpSchema.Resource&gt; parameter.
+ *
+ * @author Christian Tzolov
+ */
+public final class AsyncMcpResourceListChangedMethodCallback extends AbstractMcpResourceListChangedMethodCallback
+		implements Function<List<McpSchema.Resource>, Mono<Void>> {
+
+	private AsyncMcpResourceListChangedMethodCallback(Builder builder) {
+		super(builder.method, builder.bean);
+	}
+
+	/**
+	 * Apply the callback to the given resource list.
+	 * <p>
+	 * This method builds the arguments for the method call, invokes the method, and
+	 * returns a Mono that completes when the method execution is done.
+	 * @param updatedResources The updated list of resources, must not be null
+	 * @return A Mono that completes when the method execution is done
+	 * @throws McpResourceListChangedConsumerMethodException if there is an error invoking
+	 * the resource list changed consumer method
+	 * @throws IllegalArgumentException if the updatedResources is null
+	 */
+	@Override
+	public Mono<Void> apply(List<McpSchema.Resource> updatedResources) {
+		if (updatedResources == null) {
+			return Mono.error(new IllegalArgumentException("Updated resources list must not be null"));
+		}
+
+		try {
+			// Build arguments for the method call
+			Object[] args = this.buildArgs(this.method, null, updatedResources);
+
+			// Invoke the method
+			this.method.setAccessible(true);
+			Object result = this.method.invoke(this.bean, args);
+
+			// If the method returns a Mono, handle it
+			if (result instanceof Mono) {
+				// We need to handle the case where the Mono is not a Mono<Void>
+				// This is expected by the test testInvalidMonoReturnType
+				Mono<?> monoResult = (Mono<?>) result;
+
+				// Convert the Mono to a Mono<Void> by checking the value
+				// If the value is not null (i.e., not Void), throw a ClassCastException
+				return monoResult.flatMap(value -> {
+					if (value != null) {
+						// This will be caught by the test testInvalidMonoReturnType
+						throw new ClassCastException(
+								"Expected Mono<Void> but got Mono<" + value.getClass().getName() + ">");
+					}
+					return Mono.empty();
+				}).then();
+			}
+			// If the method returns void, return an empty Mono
+			return Mono.empty();
+		}
+		catch (Exception e) {
+			return Mono.error(new McpResourceListChangedConsumerMethodException(
+					"Error invoking resource list changed consumer method: " + this.method.getName(), e));
+		}
+	}
+
+	/**
+	 * Validates that the method return type is compatible with the resource list changed
+	 * consumer callback.
+	 * @param method The method to validate
+	 * @throws IllegalArgumentException if the return type is not compatible
+	 */
+	@Override
+	protected void validateReturnType(Method method) {
+		Class<?> returnType = method.getReturnType();
+
+		if (returnType != void.class && !Mono.class.isAssignableFrom(returnType)) {
+			throw new IllegalArgumentException("Method must have void or Mono<Void> return type: " + method.getName()
+					+ " in " + method.getDeclaringClass().getName() + " returns " + returnType.getName());
+		}
+	}
+
+	/**
+	 * Builder for creating AsyncMcpResourceListChangedMethodCallback instances.
+	 * <p>
+	 * This builder provides a fluent API for constructing
+	 * AsyncMcpResourceListChangedMethodCallback instances with the required parameters.
+	 */
+	public static class Builder extends AbstractBuilder<Builder, AsyncMcpResourceListChangedMethodCallback> {
+
+		/**
+		 * Build the callback.
+		 * @return A new AsyncMcpResourceListChangedMethodCallback instance
+		 */
+		@Override
+		public AsyncMcpResourceListChangedMethodCallback build() {
+			validate();
+			return new AsyncMcpResourceListChangedMethodCallback(this);
+		}
+
+	}
+
+	/**
+	 * Create a new builder.
+	 * @return A new builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/changed/resource/AsyncResourceListChangedSpecification.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/changed/resource/AsyncResourceListChangedSpecification.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.changed.resource;
+
+import java.util.List;
+import java.util.function.Function;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+
+public record AsyncResourceListChangedSpecification(String clientId,
+		Function<List<McpSchema.Resource>, Mono<Void>> resourceListChangeHandler) {
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/changed/resource/SyncMcpResourceListChangedMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/changed/resource/SyncMcpResourceListChangedMethodCallback.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.changed.resource;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.springaicommunity.mcp.annotation.McpResourceListChanged;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Class for creating Consumer callbacks around resource list changed consumer methods.
+ *
+ * This class provides a way to convert methods annotated with
+ * {@link McpResourceListChanged} into callback functions that can be used to handle
+ * resource list change notifications. It supports methods with a single
+ * List&lt;McpSchema.Resource&gt; parameter.
+ *
+ * @author Christian Tzolov
+ */
+public final class SyncMcpResourceListChangedMethodCallback extends AbstractMcpResourceListChangedMethodCallback
+		implements Consumer<List<McpSchema.Resource>> {
+
+	private SyncMcpResourceListChangedMethodCallback(Builder builder) {
+		super(builder.method, builder.bean);
+	}
+
+	/**
+	 * Accept the resource list change notification and process it.
+	 * <p>
+	 * This method builds the arguments for the method call and invokes the method.
+	 * @param updatedResources The updated list of resources, must not be null
+	 * @throws McpResourceListChangedConsumerMethodException if there is an error invoking
+	 * the resource list changed consumer method
+	 * @throws IllegalArgumentException if the updatedResources is null
+	 */
+	@Override
+	public void accept(List<McpSchema.Resource> updatedResources) {
+		if (updatedResources == null) {
+			throw new IllegalArgumentException("Updated resources list must not be null");
+		}
+
+		try {
+			// Build arguments for the method call
+			Object[] args = this.buildArgs(this.method, null, updatedResources);
+
+			// Invoke the method
+			this.method.setAccessible(true);
+			this.method.invoke(this.bean, args);
+		}
+		catch (Exception e) {
+			throw new McpResourceListChangedConsumerMethodException(
+					"Error invoking resource list changed consumer method: " + this.method.getName(), e);
+		}
+	}
+
+	/**
+	 * Validates that the method return type is compatible with the resource list changed
+	 * consumer callback.
+	 * @param method The method to validate
+	 * @throws IllegalArgumentException if the return type is not compatible
+	 */
+	@Override
+	protected void validateReturnType(Method method) {
+		Class<?> returnType = method.getReturnType();
+
+		if (returnType != void.class) {
+			throw new IllegalArgumentException("Method must have void return type: " + method.getName() + " in "
+					+ method.getDeclaringClass().getName() + " returns " + returnType.getName());
+		}
+	}
+
+	/**
+	 * Builder for creating SyncMcpResourceListChangedMethodCallback instances.
+	 * <p>
+	 * This builder provides a fluent API for constructing
+	 * SyncMcpResourceListChangedMethodCallback instances with the required parameters.
+	 */
+	public static class Builder extends AbstractBuilder<Builder, SyncMcpResourceListChangedMethodCallback> {
+
+		/**
+		 * Build the callback.
+		 * @return A new SyncMcpResourceListChangedMethodCallback instance
+		 */
+		@Override
+		public SyncMcpResourceListChangedMethodCallback build() {
+			validate();
+			return new SyncMcpResourceListChangedMethodCallback(this);
+		}
+
+	}
+
+	/**
+	 * Create a new builder.
+	 * @return A new builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/changed/resource/SyncResourceListChangedSpecification.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/changed/resource/SyncResourceListChangedSpecification.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.changed.resource;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+public record SyncResourceListChangedSpecification(String clientId,
+		Consumer<List<McpSchema.Resource>> resourceListChangeHandler) {
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/resource/AsyncMcpResourceListChangedProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/resource/AsyncMcpResourceListChangedProvider.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.provider.changed.resource;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.springaicommunity.mcp.annotation.McpResourceListChanged;
+import org.springaicommunity.mcp.method.changed.resource.AsyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.AsyncMcpResourceListChangedMethodCallback;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.util.Assert;
+import reactor.core.publisher.Mono;
+
+/**
+ * Provider for asynchronous resource list changed consumer callbacks.
+ *
+ * <p>
+ * This class scans a list of objects for methods annotated with
+ * {@link McpResourceListChanged} and creates {@link Function} callbacks for them. These
+ * callbacks can be used to handle resource list change notifications from MCP servers in
+ * a reactive way.
+ *
+ * <p>
+ * Example usage: <pre>{@code
+ * // Create a provider with a list of objects containing @McpResourceListChanged methods
+ * AsyncMcpResourceListChangedProvider provider = new AsyncMcpResourceListChangedProvider(List.of(resourceListHandler));
+ *
+ * // Get the list of resource list changed consumer callbacks
+ * List<AsyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+ *
+ * // Add the consumers to the client features
+ * McpClientFeatures.Async clientFeatures = new McpClientFeatures.Async(
+ *     clientInfo, clientCapabilities, roots,
+ *     toolsChangeConsumers, resourcesChangeConsumers, promptsChangeConsumers,
+ *     loggingConsumers, samplingHandler);
+ * }</pre>
+ *
+ * @author Christian Tzolov
+ * @see McpResourceListChanged
+ * @see AsyncMcpResourceListChangedMethodCallback
+ * @see AsyncResourceListChangedSpecification
+ */
+public class AsyncMcpResourceListChangedProvider {
+
+	private final List<Object> resourceListChangedConsumerObjects;
+
+	/**
+	 * Create a new AsyncMcpResourceListChangedProvider.
+	 * @param resourceListChangedConsumerObjects the objects containing methods annotated
+	 * with {@link McpResourceListChanged}
+	 */
+	public AsyncMcpResourceListChangedProvider(List<Object> resourceListChangedConsumerObjects) {
+		Assert.notNull(resourceListChangedConsumerObjects, "resourceListChangedConsumerObjects cannot be null");
+		this.resourceListChangedConsumerObjects = resourceListChangedConsumerObjects;
+	}
+
+	/**
+	 * Get the list of resource list changed consumer specifications.
+	 * @return the list of resource list changed consumer specifications
+	 */
+	public List<AsyncResourceListChangedSpecification> getResourceListChangedSpecifications() {
+
+		List<AsyncResourceListChangedSpecification> resourceListChangedConsumers = this.resourceListChangedConsumerObjects
+			.stream()
+			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
+				.filter(method -> method.isAnnotationPresent(McpResourceListChanged.class))
+				.filter(method -> method.getReturnType() == void.class
+						|| Mono.class.isAssignableFrom(method.getReturnType()))
+				.map(mcpResourceListChangedConsumerMethod -> {
+					var resourceListChangedAnnotation = mcpResourceListChangedConsumerMethod
+						.getAnnotation(McpResourceListChanged.class);
+
+					Function<List<McpSchema.Resource>, Mono<Void>> methodCallback = AsyncMcpResourceListChangedMethodCallback
+						.builder()
+						.method(mcpResourceListChangedConsumerMethod)
+						.bean(consumerObject)
+						.build();
+
+					return new AsyncResourceListChangedSpecification(resourceListChangedAnnotation.clientId(),
+							methodCallback);
+				})
+				.toList())
+			.flatMap(List::stream)
+			.toList();
+
+		return resourceListChangedConsumers;
+	}
+
+	/**
+	 * Returns the methods of the given bean class.
+	 * @param bean the bean instance
+	 * @return the methods of the bean class
+	 */
+	protected Method[] doGetClassMethods(Object bean) {
+		return bean.getClass().getDeclaredMethods();
+	}
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/resource/SyncMcpResourceListChangedProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/resource/SyncMcpResourceListChangedProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.provider.changed.resource;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.springaicommunity.mcp.annotation.McpResourceListChanged;
+import org.springaicommunity.mcp.method.changed.resource.SyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.SyncMcpResourceListChangedMethodCallback;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.util.Assert;
+import reactor.core.publisher.Mono;
+
+/**
+ * Provider for synchronous resource list changed consumer callbacks.
+ *
+ * <p>
+ * This class scans a list of objects for methods annotated with
+ * {@link McpResourceListChanged} and creates {@link Consumer} callbacks for them. These
+ * callbacks can be used to handle resource list change notifications from MCP servers.
+ *
+ * <p>
+ * Example usage: <pre>{@code
+ * // Create a provider with a list of objects containing @McpResourceListChanged methods
+ * SyncMcpResourceListChangedProvider provider = new SyncMcpResourceListChangedProvider(List.of(resourceListHandler));
+ *
+ * // Get the list of resource list changed consumer callbacks
+ * List<SyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+ *
+ * // Add the consumers to the client features
+ * McpClientFeatures.Sync clientFeatures = new McpClientFeatures.Sync(
+ *     clientInfo, clientCapabilities, roots,
+ *     toolsChangeConsumers, resourcesChangeConsumers, promptsChangeConsumers,
+ *     loggingConsumers, samplingHandler);
+ * }</pre>
+ *
+ * @author Christian Tzolov
+ * @see McpResourceListChanged
+ * @see SyncMcpResourceListChangedMethodCallback
+ * @see SyncResourceListChangedSpecification
+ */
+public class SyncMcpResourceListChangedProvider {
+
+	private final List<Object> resourceListChangedConsumerObjects;
+
+	/**
+	 * Create a new SyncMcpResourceListChangedProvider.
+	 * @param resourceListChangedConsumerObjects the objects containing methods annotated
+	 * with {@link McpResourceListChanged}
+	 */
+	public SyncMcpResourceListChangedProvider(List<Object> resourceListChangedConsumerObjects) {
+		Assert.notNull(resourceListChangedConsumerObjects, "resourceListChangedConsumerObjects cannot be null");
+		this.resourceListChangedConsumerObjects = resourceListChangedConsumerObjects;
+	}
+
+	/**
+	 * Get the list of resource list changed consumer specifications.
+	 * @return the list of resource list changed consumer specifications
+	 */
+	public List<SyncResourceListChangedSpecification> getResourceListChangedSpecifications() {
+
+		List<SyncResourceListChangedSpecification> resourceListChangedConsumers = this.resourceListChangedConsumerObjects
+			.stream()
+			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
+				.filter(method -> method.isAnnotationPresent(McpResourceListChanged.class))
+				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.map(mcpResourceListChangedConsumerMethod -> {
+					var resourceListChangedAnnotation = mcpResourceListChangedConsumerMethod
+						.getAnnotation(McpResourceListChanged.class);
+
+					Consumer<List<McpSchema.Resource>> methodCallback = SyncMcpResourceListChangedMethodCallback
+						.builder()
+						.method(mcpResourceListChangedConsumerMethod)
+						.bean(consumerObject)
+						.resourceListChanged(resourceListChangedAnnotation)
+						.build();
+
+					return new SyncResourceListChangedSpecification(resourceListChangedAnnotation.clientId(),
+							methodCallback);
+				})
+				.toList())
+			.flatMap(List::stream)
+			.toList();
+
+		return resourceListChangedConsumers;
+	}
+
+	/**
+	 * Returns the methods of the given bean class.
+	 * @param bean the bean instance
+	 * @return the methods of the bean class
+	 */
+	protected Method[] doGetClassMethods(Object bean) {
+		return bean.getClass().getDeclaredMethods();
+	}
+
+}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/changed/resource/AsyncMcpResourceListChangedMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/changed/resource/AsyncMcpResourceListChangedMethodCallbackTests.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.changed.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.annotation.McpResourceListChanged;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * Tests for {@link AsyncMcpResourceListChangedMethodCallback}.
+ *
+ * @author Christian Tzolov
+ */
+public class AsyncMcpResourceListChangedMethodCallbackTests {
+
+	private static final List<McpSchema.Resource> TEST_RESOURCES = List.of(
+			McpSchema.Resource.builder()
+				.uri("file:///test1.txt")
+				.name("test-resource-1")
+				.description("Test Resource 1")
+				.mimeType("text/plain")
+				.build(),
+			McpSchema.Resource.builder()
+				.uri("file:///test2.txt")
+				.name("test-resource-2")
+				.description("Test Resource 2")
+				.mimeType("text/plain")
+				.build());
+
+	/**
+	 * Test class with valid methods.
+	 */
+	static class ValidMethods {
+
+		private List<McpSchema.Resource> lastUpdatedResources;
+
+		@McpResourceListChanged
+		public Mono<Void> handleResourceListChanged(List<McpSchema.Resource> updatedResources) {
+			return Mono.fromRunnable(() -> {
+				this.lastUpdatedResources = updatedResources;
+			});
+		}
+
+		@McpResourceListChanged
+		public void handleResourceListChangedVoid(List<McpSchema.Resource> updatedResources) {
+			this.lastUpdatedResources = updatedResources;
+		}
+
+	}
+
+	/**
+	 * Test class with invalid methods.
+	 */
+	static class InvalidMethods {
+
+		@McpResourceListChanged
+		public String invalidReturnType(List<McpSchema.Resource> updatedResources) {
+			return "Invalid";
+		}
+
+		@McpResourceListChanged
+		public Mono<String> invalidMonoReturnType(List<McpSchema.Resource> updatedResources) {
+			return Mono.just("Invalid");
+		}
+
+		@McpResourceListChanged
+		public Mono<Void> invalidParameterCount(List<McpSchema.Resource> updatedResources, String extra) {
+			return Mono.empty();
+		}
+
+		@McpResourceListChanged
+		public Mono<Void> invalidParameterType(String invalidType) {
+			return Mono.empty();
+		}
+
+		@McpResourceListChanged
+		public Mono<Void> noParameters() {
+			return Mono.empty();
+		}
+
+	}
+
+	@Test
+	void testValidMethodWithResourceList() throws Exception {
+		ValidMethods bean = new ValidMethods();
+		Method method = ValidMethods.class.getMethod("handleResourceListChanged", List.class);
+
+		Function<List<McpSchema.Resource>, Mono<Void>> callback = AsyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		StepVerifier.create(callback.apply(TEST_RESOURCES)).verifyComplete();
+
+		assertThat(bean.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+		assertThat(bean.lastUpdatedResources).hasSize(2);
+		assertThat(bean.lastUpdatedResources.get(0).name()).isEqualTo("test-resource-1");
+		assertThat(bean.lastUpdatedResources.get(1).name()).isEqualTo("test-resource-2");
+	}
+
+	@Test
+	void testValidVoidMethod() throws Exception {
+		ValidMethods bean = new ValidMethods();
+		Method method = ValidMethods.class.getMethod("handleResourceListChangedVoid", List.class);
+
+		Function<List<McpSchema.Resource>, Mono<Void>> callback = AsyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		StepVerifier.create(callback.apply(TEST_RESOURCES)).verifyComplete();
+
+		assertThat(bean.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+		assertThat(bean.lastUpdatedResources).hasSize(2);
+		assertThat(bean.lastUpdatedResources.get(0).name()).isEqualTo("test-resource-1");
+		assertThat(bean.lastUpdatedResources.get(1).name()).isEqualTo("test-resource-2");
+	}
+
+	@Test
+	void testInvalidReturnType() throws Exception {
+		InvalidMethods bean = new InvalidMethods();
+		Method method = InvalidMethods.class.getMethod("invalidReturnType", List.class);
+
+		assertThatThrownBy(() -> AsyncMcpResourceListChangedMethodCallback.builder().method(method).bean(bean).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Method must have void or Mono<Void> return type");
+	}
+
+	@Test
+	void testInvalidMonoReturnType() throws Exception {
+		InvalidMethods bean = new InvalidMethods();
+		Method method = InvalidMethods.class.getMethod("invalidMonoReturnType", List.class);
+
+		// This will pass validation since we can't check the generic type at runtime
+		Function<List<McpSchema.Resource>, Mono<Void>> callback = AsyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		// But it will fail at runtime when we try to cast the result
+		StepVerifier.create(callback.apply(TEST_RESOURCES)).verifyError(ClassCastException.class);
+	}
+
+	@Test
+	void testInvalidParameterCount() throws Exception {
+		InvalidMethods bean = new InvalidMethods();
+		Method method = InvalidMethods.class.getMethod("invalidParameterCount", List.class, String.class);
+
+		assertThatThrownBy(() -> AsyncMcpResourceListChangedMethodCallback.builder().method(method).bean(bean).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Method must have exactly 1 parameter (List<McpSchema.Resource>)");
+	}
+
+	@Test
+	void testInvalidParameterType() throws Exception {
+		InvalidMethods bean = new InvalidMethods();
+		Method method = InvalidMethods.class.getMethod("invalidParameterType", String.class);
+
+		assertThatThrownBy(() -> AsyncMcpResourceListChangedMethodCallback.builder().method(method).bean(bean).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Parameter must be of type List<McpSchema.Resource>");
+	}
+
+	@Test
+	void testNoParameters() throws Exception {
+		InvalidMethods bean = new InvalidMethods();
+		Method method = InvalidMethods.class.getMethod("noParameters");
+
+		assertThatThrownBy(() -> AsyncMcpResourceListChangedMethodCallback.builder().method(method).bean(bean).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Method must have exactly 1 parameter (List<McpSchema.Resource>)");
+	}
+
+	@Test
+	void testNullResourceList() throws Exception {
+		ValidMethods bean = new ValidMethods();
+		Method method = ValidMethods.class.getMethod("handleResourceListChanged", List.class);
+
+		Function<List<McpSchema.Resource>, Mono<Void>> callback = AsyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		StepVerifier.create(callback.apply(null)).verifyErrorSatisfies(e -> {
+			assertThat(e).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Updated resources list must not be null");
+		});
+	}
+
+	@Test
+	void testEmptyResourceList() throws Exception {
+		ValidMethods bean = new ValidMethods();
+		Method method = ValidMethods.class.getMethod("handleResourceListChanged", List.class);
+
+		Function<List<McpSchema.Resource>, Mono<Void>> callback = AsyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		List<McpSchema.Resource> emptyList = List.of();
+		StepVerifier.create(callback.apply(emptyList)).verifyComplete();
+
+		assertThat(bean.lastUpdatedResources).isEqualTo(emptyList);
+		assertThat(bean.lastUpdatedResources).isEmpty();
+	}
+
+	@Test
+	void testNullMethod() {
+		ValidMethods bean = new ValidMethods();
+
+		assertThatThrownBy(() -> AsyncMcpResourceListChangedMethodCallback.builder().method(null).bean(bean).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Method must not be null");
+	}
+
+	@Test
+	void testNullBean() throws Exception {
+		Method method = ValidMethods.class.getMethod("handleResourceListChanged", List.class);
+
+		assertThatThrownBy(() -> AsyncMcpResourceListChangedMethodCallback.builder().method(method).bean(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Bean must not be null");
+	}
+
+	@Test
+	void testMethodInvocationException() throws Exception {
+		// Test class that throws an exception in the method
+		class ThrowingMethod {
+
+			@McpResourceListChanged
+			public Mono<Void> handleResourceListChanged(List<McpSchema.Resource> updatedResources) {
+				return Mono.fromRunnable(() -> {
+					throw new RuntimeException("Test exception");
+				});
+			}
+
+		}
+
+		ThrowingMethod bean = new ThrowingMethod();
+		Method method = ThrowingMethod.class.getMethod("handleResourceListChanged", List.class);
+
+		Function<List<McpSchema.Resource>, Mono<Void>> callback = AsyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		StepVerifier.create(callback.apply(TEST_RESOURCES)).verifyError(RuntimeException.class);
+	}
+
+	@Test
+	void testMethodInvocationExceptionVoid() throws Exception {
+		// Test class that throws an exception in a void method
+		class ThrowingVoidMethod {
+
+			@McpResourceListChanged
+			public void handleResourceListChanged(List<McpSchema.Resource> updatedResources) {
+				throw new RuntimeException("Test exception");
+			}
+
+		}
+
+		ThrowingVoidMethod bean = new ThrowingVoidMethod();
+		Method method = ThrowingVoidMethod.class.getMethod("handleResourceListChanged", List.class);
+
+		Function<List<McpSchema.Resource>, Mono<Void>> callback = AsyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		StepVerifier.create(callback.apply(TEST_RESOURCES)).verifyErrorSatisfies(e -> {
+			assertThat(e).isInstanceOf(
+					AbstractMcpResourceListChangedMethodCallback.McpResourceListChangedConsumerMethodException.class)
+				.hasMessageContaining("Error invoking resource list changed consumer method");
+		});
+	}
+
+}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/changed/resource/SyncMcpResourceListChangedMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/changed/resource/SyncMcpResourceListChangedMethodCallbackTests.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.method.changed.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.annotation.McpResourceListChanged;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Tests for {@link SyncMcpResourceListChangedMethodCallback}.
+ *
+ * @author Christian Tzolov
+ */
+public class SyncMcpResourceListChangedMethodCallbackTests {
+
+	private static final List<McpSchema.Resource> TEST_RESOURCES = List.of(
+			McpSchema.Resource.builder()
+				.uri("file:///test1.txt")
+				.name("test-resource-1")
+				.description("Test Resource 1")
+				.mimeType("text/plain")
+				.build(),
+			McpSchema.Resource.builder()
+				.uri("file:///test2.txt")
+				.name("test-resource-2")
+				.description("Test Resource 2")
+				.mimeType("text/plain")
+				.build());
+
+	/**
+	 * Test class with valid methods.
+	 */
+	static class ValidMethods {
+
+		private List<McpSchema.Resource> lastUpdatedResources;
+
+		@McpResourceListChanged
+		public void handleResourceListChanged(List<McpSchema.Resource> updatedResources) {
+			this.lastUpdatedResources = updatedResources;
+		}
+
+	}
+
+	/**
+	 * Test class with invalid methods.
+	 */
+	static class InvalidMethods {
+
+		@McpResourceListChanged
+		public String invalidReturnType(List<McpSchema.Resource> updatedResources) {
+			return "Invalid";
+		}
+
+		@McpResourceListChanged
+		public void invalidParameterCount(List<McpSchema.Resource> updatedResources, String extra) {
+			// Invalid parameter count
+		}
+
+		@McpResourceListChanged
+		public void invalidParameterType(String invalidType) {
+			// Invalid parameter type
+		}
+
+		@McpResourceListChanged
+		public void noParameters() {
+			// No parameters
+		}
+
+	}
+
+	@Test
+	void testValidMethodWithResourceList() throws Exception {
+		ValidMethods bean = new ValidMethods();
+		Method method = ValidMethods.class.getMethod("handleResourceListChanged", List.class);
+
+		Consumer<List<McpSchema.Resource>> callback = SyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		callback.accept(TEST_RESOURCES);
+
+		assertThat(bean.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+		assertThat(bean.lastUpdatedResources).hasSize(2);
+		assertThat(bean.lastUpdatedResources.get(0).name()).isEqualTo("test-resource-1");
+		assertThat(bean.lastUpdatedResources.get(1).name()).isEqualTo("test-resource-2");
+	}
+
+	@Test
+	void testInvalidReturnType() throws Exception {
+		InvalidMethods bean = new InvalidMethods();
+		Method method = InvalidMethods.class.getMethod("invalidReturnType", List.class);
+
+		assertThatThrownBy(() -> SyncMcpResourceListChangedMethodCallback.builder().method(method).bean(bean).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Method must have void return type");
+	}
+
+	@Test
+	void testInvalidParameterCount() throws Exception {
+		InvalidMethods bean = new InvalidMethods();
+		Method method = InvalidMethods.class.getMethod("invalidParameterCount", List.class, String.class);
+
+		assertThatThrownBy(() -> SyncMcpResourceListChangedMethodCallback.builder().method(method).bean(bean).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Method must have exactly 1 parameter (List<McpSchema.Resource>)");
+	}
+
+	@Test
+	void testInvalidParameterType() throws Exception {
+		InvalidMethods bean = new InvalidMethods();
+		Method method = InvalidMethods.class.getMethod("invalidParameterType", String.class);
+
+		assertThatThrownBy(() -> SyncMcpResourceListChangedMethodCallback.builder().method(method).bean(bean).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Parameter must be of type List<McpSchema.Resource>");
+	}
+
+	@Test
+	void testNoParameters() throws Exception {
+		InvalidMethods bean = new InvalidMethods();
+		Method method = InvalidMethods.class.getMethod("noParameters");
+
+		assertThatThrownBy(() -> SyncMcpResourceListChangedMethodCallback.builder().method(method).bean(bean).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Method must have exactly 1 parameter (List<McpSchema.Resource>)");
+	}
+
+	@Test
+	void testNullResourceList() throws Exception {
+		ValidMethods bean = new ValidMethods();
+		Method method = ValidMethods.class.getMethod("handleResourceListChanged", List.class);
+
+		Consumer<List<McpSchema.Resource>> callback = SyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		assertThatThrownBy(() -> callback.accept(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Updated resources list must not be null");
+	}
+
+	@Test
+	void testEmptyResourceList() throws Exception {
+		ValidMethods bean = new ValidMethods();
+		Method method = ValidMethods.class.getMethod("handleResourceListChanged", List.class);
+
+		Consumer<List<McpSchema.Resource>> callback = SyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		List<McpSchema.Resource> emptyList = List.of();
+		callback.accept(emptyList);
+
+		assertThat(bean.lastUpdatedResources).isEqualTo(emptyList);
+		assertThat(bean.lastUpdatedResources).isEmpty();
+	}
+
+	@Test
+	void testNullMethod() {
+		ValidMethods bean = new ValidMethods();
+
+		assertThatThrownBy(() -> SyncMcpResourceListChangedMethodCallback.builder().method(null).bean(bean).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Method must not be null");
+	}
+
+	@Test
+	void testNullBean() throws Exception {
+		Method method = ValidMethods.class.getMethod("handleResourceListChanged", List.class);
+
+		assertThatThrownBy(() -> SyncMcpResourceListChangedMethodCallback.builder().method(method).bean(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Bean must not be null");
+	}
+
+	@Test
+	void testMethodInvocationException() throws Exception {
+		// Test class that throws an exception in the method
+		class ThrowingMethod {
+
+			@McpResourceListChanged
+			public void handleResourceListChanged(List<McpSchema.Resource> updatedResources) {
+				throw new RuntimeException("Test exception");
+			}
+
+		}
+
+		ThrowingMethod bean = new ThrowingMethod();
+		Method method = ThrowingMethod.class.getMethod("handleResourceListChanged", List.class);
+
+		Consumer<List<McpSchema.Resource>> callback = SyncMcpResourceListChangedMethodCallback.builder()
+			.method(method)
+			.bean(bean)
+			.build();
+
+		assertThatThrownBy(() -> callback.accept(TEST_RESOURCES))
+			.isInstanceOf(
+					AbstractMcpResourceListChangedMethodCallback.McpResourceListChangedConsumerMethodException.class)
+			.hasMessageContaining("Error invoking resource list changed consumer method");
+	}
+
+}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/changed/resource/AsyncMcpResourceListChangedProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/changed/resource/AsyncMcpResourceListChangedProviderTests.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.provider.changed.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.annotation.McpResourceListChanged;
+import org.springaicommunity.mcp.method.changed.resource.AsyncResourceListChangedSpecification;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * Tests for {@link AsyncMcpResourceListChangedProvider}.
+ *
+ * @author Christian Tzolov
+ */
+public class AsyncMcpResourceListChangedProviderTests {
+
+	private static final List<McpSchema.Resource> TEST_RESOURCES = List.of(
+			McpSchema.Resource.builder()
+				.uri("file:///test1.txt")
+				.name("test-resource-1")
+				.description("Test Resource 1")
+				.mimeType("text/plain")
+				.build(),
+			McpSchema.Resource.builder()
+				.uri("file:///test2.txt")
+				.name("test-resource-2")
+				.description("Test Resource 2")
+				.mimeType("text/plain")
+				.build());
+
+	/**
+	 * Test class with resource list changed consumer methods.
+	 */
+	static class ResourceListChangedHandler {
+
+		private List<McpSchema.Resource> lastUpdatedResources;
+
+		@McpResourceListChanged
+		public Mono<Void> handleResourceListChanged(List<McpSchema.Resource> updatedResources) {
+			return Mono.fromRunnable(() -> {
+				this.lastUpdatedResources = updatedResources;
+			});
+		}
+
+		@McpResourceListChanged(clientId = "test-client")
+		public Mono<Void> handleResourceListChangedWithClientId(List<McpSchema.Resource> updatedResources) {
+			return Mono.fromRunnable(() -> {
+				this.lastUpdatedResources = updatedResources;
+			});
+		}
+
+		@McpResourceListChanged
+		public void handleResourceListChangedVoid(List<McpSchema.Resource> updatedResources) {
+			this.lastUpdatedResources = updatedResources;
+		}
+
+		// This method is not annotated and should be ignored
+		public Mono<Void> notAnnotatedMethod(List<McpSchema.Resource> updatedResources) {
+			return Mono.empty();
+		}
+
+	}
+
+	@Test
+	void testGetResourceListChangedSpecifications() {
+		ResourceListChangedHandler handler = new ResourceListChangedHandler();
+		AsyncMcpResourceListChangedProvider provider = new AsyncMcpResourceListChangedProvider(List.of(handler));
+
+		List<AsyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+		List<Function<List<McpSchema.Resource>, Mono<Void>>> consumers = specifications.stream()
+			.map(AsyncResourceListChangedSpecification::resourceListChangeHandler)
+			.toList();
+
+		// Should find 3 annotated methods (2 Mono<Void> + 1 void)
+		assertThat(consumers).hasSize(3);
+		assertThat(specifications).hasSize(3);
+
+		// Test the first consumer
+		StepVerifier.create(consumers.get(0).apply(TEST_RESOURCES)).verifyComplete();
+
+		// Verify that the method was called
+		assertThat(handler.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+		assertThat(handler.lastUpdatedResources).hasSize(2);
+		assertThat(handler.lastUpdatedResources.get(0).name()).isEqualTo("test-resource-1");
+		assertThat(handler.lastUpdatedResources.get(1).name()).isEqualTo("test-resource-2");
+
+		// Test the second consumer
+		StepVerifier.create(consumers.get(1).apply(TEST_RESOURCES)).verifyComplete();
+
+		// Verify that the method was called
+		assertThat(handler.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+
+		// Test the third consumer (void method)
+		StepVerifier.create(consumers.get(2).apply(TEST_RESOURCES)).verifyComplete();
+
+		// Verify that the method was called
+		assertThat(handler.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+	}
+
+	@Test
+	void testClientIdSpecifications() {
+		ResourceListChangedHandler handler = new ResourceListChangedHandler();
+		AsyncMcpResourceListChangedProvider provider = new AsyncMcpResourceListChangedProvider(List.of(handler));
+
+		List<AsyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+
+		// Should find 3 specifications
+		assertThat(specifications).hasSize(3);
+
+		// Check client IDs
+		List<String> clientIds = specifications.stream().map(AsyncResourceListChangedSpecification::clientId).toList();
+
+		assertThat(clientIds).containsExactlyInAnyOrder("", "test-client", "");
+	}
+
+	@Test
+	void testEmptyList() {
+		AsyncMcpResourceListChangedProvider provider = new AsyncMcpResourceListChangedProvider(List.of());
+
+		List<Function<List<McpSchema.Resource>, Mono<Void>>> consumers = provider.getResourceListChangedSpecifications()
+			.stream()
+			.map(AsyncResourceListChangedSpecification::resourceListChangeHandler)
+			.toList();
+
+		assertThat(consumers).isEmpty();
+	}
+
+	@Test
+	void testMultipleObjects() {
+		ResourceListChangedHandler handler1 = new ResourceListChangedHandler();
+		ResourceListChangedHandler handler2 = new ResourceListChangedHandler();
+		AsyncMcpResourceListChangedProvider provider = new AsyncMcpResourceListChangedProvider(
+				List.of(handler1, handler2));
+
+		List<Function<List<McpSchema.Resource>, Mono<Void>>> consumers = provider.getResourceListChangedSpecifications()
+			.stream()
+			.map(AsyncResourceListChangedSpecification::resourceListChangeHandler)
+			.toList();
+
+		// Should find 6 annotated methods (3 from each handler)
+		assertThat(consumers).hasSize(6);
+	}
+
+	@Test
+	void testConsumerFunctionality() {
+		ResourceListChangedHandler handler = new ResourceListChangedHandler();
+		AsyncMcpResourceListChangedProvider provider = new AsyncMcpResourceListChangedProvider(List.of(handler));
+
+		List<AsyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+		Function<List<McpSchema.Resource>, Mono<Void>> consumer = specifications.get(0).resourceListChangeHandler();
+
+		// Test with empty list
+		List<McpSchema.Resource> emptyList = List.of();
+		StepVerifier.create(consumer.apply(emptyList)).verifyComplete();
+		assertThat(handler.lastUpdatedResources).isEqualTo(emptyList);
+		assertThat(handler.lastUpdatedResources).isEmpty();
+
+		// Test with test resources
+		StepVerifier.create(consumer.apply(TEST_RESOURCES)).verifyComplete();
+		assertThat(handler.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+		assertThat(handler.lastUpdatedResources).hasSize(2);
+	}
+
+	@Test
+	void testNonAnnotatedMethodsIgnored() {
+		ResourceListChangedHandler handler = new ResourceListChangedHandler();
+		AsyncMcpResourceListChangedProvider provider = new AsyncMcpResourceListChangedProvider(List.of(handler));
+
+		List<AsyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+
+		// Should only find annotated methods, not the non-annotated one
+		assertThat(specifications).hasSize(3);
+	}
+
+	/**
+	 * Test class with methods that should be filtered out (non-reactive return types).
+	 */
+	static class InvalidReturnTypeHandler {
+
+		@McpResourceListChanged
+		public String invalidReturnType(List<McpSchema.Resource> updatedResources) {
+			return "Invalid";
+		}
+
+		@McpResourceListChanged
+		public int anotherInvalidReturnType(List<McpSchema.Resource> updatedResources) {
+			return 42;
+		}
+
+	}
+
+	@Test
+	void testInvalidReturnTypesFiltered() {
+		InvalidReturnTypeHandler handler = new InvalidReturnTypeHandler();
+		AsyncMcpResourceListChangedProvider provider = new AsyncMcpResourceListChangedProvider(List.of(handler));
+
+		List<AsyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+
+		// Should find no methods since they have invalid return types
+		assertThat(specifications).isEmpty();
+	}
+
+	/**
+	 * Test class with mixed valid and invalid methods.
+	 */
+	static class MixedHandler {
+
+		private List<McpSchema.Resource> lastUpdatedResources;
+
+		@McpResourceListChanged
+		public Mono<Void> validMethod(List<McpSchema.Resource> updatedResources) {
+			return Mono.fromRunnable(() -> {
+				this.lastUpdatedResources = updatedResources;
+			});
+		}
+
+		@McpResourceListChanged
+		public void validVoidMethod(List<McpSchema.Resource> updatedResources) {
+			this.lastUpdatedResources = updatedResources;
+		}
+
+		@McpResourceListChanged
+		public String invalidMethod(List<McpSchema.Resource> updatedResources) {
+			return "Invalid";
+		}
+
+	}
+
+	@Test
+	void testMixedValidAndInvalidMethods() {
+		MixedHandler handler = new MixedHandler();
+		AsyncMcpResourceListChangedProvider provider = new AsyncMcpResourceListChangedProvider(List.of(handler));
+
+		List<AsyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+
+		// Should find only the 2 valid methods (Mono<Void> and void)
+		assertThat(specifications).hasSize(2);
+
+		// Test that the valid methods work
+		Function<List<McpSchema.Resource>, Mono<Void>> consumer = specifications.get(0).resourceListChangeHandler();
+		StepVerifier.create(consumer.apply(TEST_RESOURCES)).verifyComplete();
+		assertThat(handler.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+	}
+
+}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/changed/resource/SyncMcpResourceListChangedProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/changed/resource/SyncMcpResourceListChangedProviderTests.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.provider.changed.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.annotation.McpResourceListChanged;
+import org.springaicommunity.mcp.method.changed.resource.SyncResourceListChangedSpecification;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Tests for {@link SyncMcpResourceListChangedProvider}.
+ *
+ * @author Christian Tzolov
+ */
+public class SyncMcpResourceListChangedProviderTests {
+
+	private static final List<McpSchema.Resource> TEST_RESOURCES = List.of(
+			McpSchema.Resource.builder()
+				.uri("file:///test1.txt")
+				.name("test-resource-1")
+				.description("Test Resource 1")
+				.mimeType("text/plain")
+				.build(),
+			McpSchema.Resource.builder()
+				.uri("file:///test2.txt")
+				.name("test-resource-2")
+				.description("Test Resource 2")
+				.mimeType("text/plain")
+				.build());
+
+	/**
+	 * Test class with resource list changed consumer methods.
+	 */
+	static class ResourceListChangedHandler {
+
+		private List<McpSchema.Resource> lastUpdatedResources;
+
+		@McpResourceListChanged
+		public void handleResourceListChanged(List<McpSchema.Resource> updatedResources) {
+			this.lastUpdatedResources = updatedResources;
+		}
+
+		@McpResourceListChanged(clientId = "test-client")
+		public void handleResourceListChangedWithClientId(List<McpSchema.Resource> updatedResources) {
+			this.lastUpdatedResources = updatedResources;
+		}
+
+		// This method is not annotated and should be ignored
+		public void notAnnotatedMethod(List<McpSchema.Resource> updatedResources) {
+			// This method should be ignored
+		}
+
+	}
+
+	@Test
+	void testGetResourceListChangedSpecifications() {
+		ResourceListChangedHandler handler = new ResourceListChangedHandler();
+		SyncMcpResourceListChangedProvider provider = new SyncMcpResourceListChangedProvider(List.of(handler));
+
+		List<SyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+		List<Consumer<List<McpSchema.Resource>>> consumers = specifications.stream()
+			.map(SyncResourceListChangedSpecification::resourceListChangeHandler)
+			.toList();
+
+		// Should find 2 annotated methods
+		assertThat(consumers).hasSize(2);
+		assertThat(specifications).hasSize(2);
+
+		// Test the first consumer
+		consumers.get(0).accept(TEST_RESOURCES);
+
+		// Verify that the method was called
+		assertThat(handler.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+		assertThat(handler.lastUpdatedResources).hasSize(2);
+		assertThat(handler.lastUpdatedResources.get(0).name()).isEqualTo("test-resource-1");
+		assertThat(handler.lastUpdatedResources.get(1).name()).isEqualTo("test-resource-2");
+
+		// Test the second consumer
+		consumers.get(1).accept(TEST_RESOURCES);
+
+		// Verify that the method was called
+		assertThat(handler.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+	}
+
+	@Test
+	void testClientIdSpecifications() {
+		ResourceListChangedHandler handler = new ResourceListChangedHandler();
+		SyncMcpResourceListChangedProvider provider = new SyncMcpResourceListChangedProvider(List.of(handler));
+
+		List<SyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+
+		// Should find 2 specifications
+		assertThat(specifications).hasSize(2);
+
+		// Check client IDs
+		List<String> clientIds = specifications.stream().map(SyncResourceListChangedSpecification::clientId).toList();
+
+		assertThat(clientIds).containsExactlyInAnyOrder("", "test-client");
+	}
+
+	@Test
+	void testEmptyList() {
+		SyncMcpResourceListChangedProvider provider = new SyncMcpResourceListChangedProvider(List.of());
+
+		List<Consumer<List<McpSchema.Resource>>> consumers = provider.getResourceListChangedSpecifications()
+			.stream()
+			.map(SyncResourceListChangedSpecification::resourceListChangeHandler)
+			.toList();
+
+		assertThat(consumers).isEmpty();
+	}
+
+	@Test
+	void testMultipleObjects() {
+		ResourceListChangedHandler handler1 = new ResourceListChangedHandler();
+		ResourceListChangedHandler handler2 = new ResourceListChangedHandler();
+		SyncMcpResourceListChangedProvider provider = new SyncMcpResourceListChangedProvider(
+				List.of(handler1, handler2));
+
+		List<Consumer<List<McpSchema.Resource>>> consumers = provider.getResourceListChangedSpecifications()
+			.stream()
+			.map(SyncResourceListChangedSpecification::resourceListChangeHandler)
+			.toList();
+
+		// Should find 4 annotated methods (2 from each handler)
+		assertThat(consumers).hasSize(4);
+	}
+
+	@Test
+	void testConsumerFunctionality() {
+		ResourceListChangedHandler handler = new ResourceListChangedHandler();
+		SyncMcpResourceListChangedProvider provider = new SyncMcpResourceListChangedProvider(List.of(handler));
+
+		List<SyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+		Consumer<List<McpSchema.Resource>> consumer = specifications.get(0).resourceListChangeHandler();
+
+		// Test with empty list
+		List<McpSchema.Resource> emptyList = List.of();
+		consumer.accept(emptyList);
+		assertThat(handler.lastUpdatedResources).isEqualTo(emptyList);
+		assertThat(handler.lastUpdatedResources).isEmpty();
+
+		// Test with test resources
+		consumer.accept(TEST_RESOURCES);
+		assertThat(handler.lastUpdatedResources).isEqualTo(TEST_RESOURCES);
+		assertThat(handler.lastUpdatedResources).hasSize(2);
+	}
+
+	@Test
+	void testNonAnnotatedMethodsIgnored() {
+		ResourceListChangedHandler handler = new ResourceListChangedHandler();
+		SyncMcpResourceListChangedProvider provider = new SyncMcpResourceListChangedProvider(List.of(handler));
+
+		List<SyncResourceListChangedSpecification> specifications = provider.getResourceListChangedSpecifications();
+
+		// Should only find annotated methods, not the non-annotated one
+		assertThat(specifications).hasSize(2);
+	}
+
+}


### PR DESCRIPTION
- Add @McpResourceListChanged annotation for handling resource list change notifications
- Implement AbstractMcpResourceListChangedMethodCallback base class
- Add SyncMcpResourceListChangedMethodCallback and AsyncMcpResourceListChangedMethodCallback implementations
- Create SyncMcpResourceListChangedProvider and AsyncMcpResourceListChangedProvider
- Add Spring integration support with specification classes
- Add tests for all method callbacks and providers
- Update README with comprehensive examples and documentation