### PR TITLE
Make clientId required for @McpLogging annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The Spring integration module provides seamless integration with Spring AI and S
 ### Annotations
 
 #### Client
-- **`@McpLogging`** - Annotates methods that handle logging message notifications from MCP servers
+- **`@McpLogging`** - Annotates methods that handle logging message notifications from MCP servers (requires `clientId` parameter)
 - **`@McpSampling`** - Annotates methods that handle sampling requests from MCP servers
 - **`@McpElicitation`** - Annotates methods that handle elicitation requests to gather additional information from users
 - **`@McpProgress`** - Annotates methods that handle progress notifications for long-running operations
@@ -931,9 +931,10 @@ public class LoggingHandler {
 
     /**
      * Handle logging message notifications with a single parameter.
+     * Note: clientId is now required for all @McpLogging annotations.
      * @param notification The logging message notification
      */
-    @McpLogging
+    @McpLogging(clientId = "default-client")
     public void handleLoggingMessage(LoggingMessageNotification notification) {
         System.out.println("Received logging message: " + notification.level() + " - " + notification.logger() + " - "
                 + notification.data());
@@ -941,11 +942,12 @@ public class LoggingHandler {
 
     /**
      * Handle logging message notifications with individual parameters.
+     * Note: clientId is now required for all @McpLogging annotations.
      * @param level The logging level
      * @param logger The logger name
      * @param data The log message data
      */
-    @McpLogging
+    @McpLogging(clientId = "default-client")
     public void handleLoggingMessageWithParams(LoggingLevel level, String logger, String data) {
         System.out.println("Received logging message with params: " + level + " - " + logger + " - " + data);
     }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpLogging.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpLogging.java
@@ -52,9 +52,9 @@ import java.lang.annotation.Target;
 public @interface McpLogging {
 
 	/**
-	 * Used as connection or client identifier to select the MCP client, the logging
-	 * consumer is associated with. If not specified, is applied to all clients.
+	 * Used as connection or client identifier to select the MCP clients, the logging
+	 * consumer is associated with. At least one client ID must be specified.
 	 */
-	String clientId() default "";
+	String clientId();
 
 }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/logging/AsyncLoggingSpecification.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/logging/AsyncLoggingSpecification.java
@@ -4,6 +4,7 @@
 
 package org.springaicommunity.mcp.method.logging;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
@@ -11,4 +12,13 @@ import reactor.core.publisher.Mono;
 
 public record AsyncLoggingSpecification(String clientId,
 		Function<LoggingMessageNotification, Mono<Void>> loggingHandler) {
+
+	public AsyncLoggingSpecification {
+		Objects.requireNonNull(clientId, "clientId must not be null");
+		if (clientId.trim().isEmpty()) {
+			throw new IllegalArgumentException("clientId must not be empty");
+		}
+		Objects.requireNonNull(loggingHandler, "loggingHandler must not be null");
+	}
+
 }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/logging/SyncLoggingSpecification.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/logging/SyncLoggingSpecification.java
@@ -4,9 +4,18 @@
 
 package org.springaicommunity.mcp.method.logging;
 
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 
 public record SyncLoggingSpecification(String clientId, Consumer<LoggingMessageNotification> loggingHandler) {
+
+	public SyncLoggingSpecification {
+		Objects.requireNonNull(clientId, "clientId must not be null");
+		if (clientId.trim().isEmpty()) {
+			throw new IllegalArgumentException("clientId must not be empty");
+		}
+		Objects.requireNonNull(loggingHandler, "loggingHandler must not be null");
+	}
 }

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/logging/AsyncMcpLoggingMethodCallbackExample.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/logging/AsyncMcpLoggingMethodCallbackExample.java
@@ -29,7 +29,7 @@ public class AsyncMcpLoggingMethodCallbackExample {
 	 * @param notification The logging message notification
 	 * @return A Mono that completes when the processing is done
 	 */
-	@McpLogging
+	@McpLogging(clientId = "test-client")
 	public Mono<Void> handleLoggingMessage(LoggingMessageNotification notification) {
 		return Mono.fromRunnable(() -> {
 			System.out.println("Received logging message: " + notification.level() + " - " + notification.logger()
@@ -45,7 +45,7 @@ public class AsyncMcpLoggingMethodCallbackExample {
 	 * @param data The log message data
 	 * @return A Mono that completes when the processing is done
 	 */
-	@McpLogging
+	@McpLogging(clientId = "test-client")
 	public Mono<Void> handleLoggingMessageWithParams(LoggingLevel level, String logger, String data) {
 		return Mono.fromRunnable(() -> {
 			System.out.println("Received logging message with params: " + level + " - " + logger + " - " + data);
@@ -56,7 +56,7 @@ public class AsyncMcpLoggingMethodCallbackExample {
 	 * Example method that accepts a LoggingMessageNotification with void return type.
 	 * @param notification The logging message notification
 	 */
-	@McpLogging
+	@McpLogging(clientId = "test-client")
 	public void handleLoggingMessageVoid(LoggingMessageNotification notification) {
 		System.out.println("Received logging message (void): " + notification.level() + " - " + notification.logger()
 				+ " - " + notification.data());

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/logging/AsyncMcpLoggingMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/logging/AsyncMcpLoggingMethodCallbackTests.java
@@ -41,14 +41,14 @@ public class AsyncMcpLoggingMethodCallbackTests {
 
 		private String lastData;
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public Mono<Void> handleLoggingMessage(LoggingMessageNotification notification) {
 			return Mono.fromRunnable(() -> {
 				this.lastNotification = notification;
 			});
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public Mono<Void> handleLoggingMessageWithParams(LoggingLevel level, String logger, String data) {
 			return Mono.fromRunnable(() -> {
 				this.lastLevel = level;
@@ -57,7 +57,7 @@ public class AsyncMcpLoggingMethodCallbackTests {
 			});
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public void handleLoggingMessageVoid(LoggingMessageNotification notification) {
 			this.lastNotification = notification;
 		}
@@ -69,27 +69,27 @@ public class AsyncMcpLoggingMethodCallbackTests {
 	 */
 	static class InvalidMethods {
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public String invalidReturnType(LoggingMessageNotification notification) {
 			return "Invalid";
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public Mono<String> invalidMonoReturnType(LoggingMessageNotification notification) {
 			return Mono.just("Invalid");
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public Mono<Void> invalidParameterCount(LoggingMessageNotification notification, String extra) {
 			return Mono.empty();
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public Mono<Void> invalidParameterType(String invalidType) {
 			return Mono.empty();
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public Mono<Void> invalidParameterTypes(String level, int logger, boolean data) {
 			return Mono.empty();
 		}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/logging/SyncMcpLoggingMethodCallbackExample.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/logging/SyncMcpLoggingMethodCallbackExample.java
@@ -27,7 +27,7 @@ public class SyncMcpLoggingMethodCallbackExample {
 	 * Example method that accepts a LoggingMessageNotification.
 	 * @param notification The logging message notification
 	 */
-	@McpLogging
+	@McpLogging(clientId = "test-client")
 	public void handleLoggingMessage(LoggingMessageNotification notification) {
 		System.out.println("Received logging message: " + notification.level() + " - " + notification.logger() + " - "
 				+ notification.data());
@@ -39,7 +39,7 @@ public class SyncMcpLoggingMethodCallbackExample {
 	 * @param logger The logger name
 	 * @param data The log message data
 	 */
-	@McpLogging
+	@McpLogging(clientId = "test-client")
 	public void handleLoggingMessageWithParams(LoggingLevel level, String logger, String data) {
 		System.out.println("Received logging message with params: " + level + " - " + logger + " - " + data);
 	}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/logging/SyncMcpLoggingMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/logging/SyncMcpLoggingMethodCallbackTests.java
@@ -39,12 +39,12 @@ public class SyncMcpLoggingMethodCallbackTests {
 
 		private String lastData;
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public void handleLoggingMessage(LoggingMessageNotification notification) {
 			this.lastNotification = notification;
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public void handleLoggingMessageWithParams(LoggingLevel level, String logger, String data) {
 			this.lastLevel = level;
 			this.lastLogger = logger;
@@ -58,22 +58,22 @@ public class SyncMcpLoggingMethodCallbackTests {
 	 */
 	static class InvalidMethods {
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public String invalidReturnType(LoggingMessageNotification notification) {
 			return "Invalid";
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public void invalidParameterCount(LoggingMessageNotification notification, String extra) {
 			// Invalid parameter count
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public void invalidParameterType(String invalidType) {
 			// Invalid parameter type
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public void invalidParameterTypes(String level, int logger, boolean data) {
 			// Invalid parameter types
 		}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/logging/AsyncMcpLoggingProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/logging/AsyncMcpLoggingProviderTests.java
@@ -38,14 +38,14 @@ public class AsyncMcpLoggingProviderTests {
 
 		private String lastData;
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public Mono<Void> handleLoggingMessage(LoggingMessageNotification notification) {
 			return Mono.fromRunnable(() -> {
 				this.lastNotification = notification;
 			});
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public Mono<Void> handleLoggingMessageWithParams(LoggingLevel level, String logger, String data) {
 			return Mono.fromRunnable(() -> {
 				this.lastLevel = level;
@@ -54,7 +54,7 @@ public class AsyncMcpLoggingProviderTests {
 			});
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public void handleLoggingMessageVoid(LoggingMessageNotification notification) {
 			this.lastNotification = notification;
 		}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/logging/SyncMcpLoggingProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/logging/SyncMcpLoggingProviderTests.java
@@ -36,12 +36,12 @@ public class SyncMcpLoggingProviderTests {
 
 		private String lastData;
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public void handleLoggingMessage(LoggingMessageNotification notification) {
 			this.lastNotification = notification;
 		}
 
-		@McpLogging
+		@McpLogging(clientId = "test-client")
 		public void handleLoggingMessageWithParams(LoggingLevel level, String logger, String data) {
 			this.lastLevel = level;
 			this.lastLogger = logger;


### PR DESCRIPTION
- Breaking change!
- Change @McpLogging.clientId from optional to required parameter
- Add validation in AsyncLoggingSpecification and SyncLoggingSpecification constructors
- Update all test examples to include explicit clientId values
- Update README documentation to reflect clientId requirement