### PR TITLE
refactor: move adapter classes to dedicated package and fix naming typos

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/CompleteAdapter.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/CompleteAdapter.java
@@ -1,12 +1,13 @@
 /*
 * Copyright 2025 - 2025 the original author or authors.
 */
-package org.springaicommunity.mcp.annotation;
+package org.springaicommunity.mcp.adapter;
 
 import java.lang.reflect.Method;
 
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.util.Assert;
+import org.springaicommunity.mcp.annotation.McpComplete;
 
 /**
  * Utility class for adapting between McpComplete annotations and

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/PromptAdapter.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/PromptAdapter.java
@@ -1,7 +1,7 @@
 /*
 * Copyright 2025 - 2025 the original author or authors.
 */
-package org.springaicommunity.mcp.annotation;
+package org.springaicommunity.mcp.adapter;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -10,15 +10,17 @@ import java.util.List;
 
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.util.Assert;
+import org.springaicommunity.mcp.annotation.McpArg;
+import org.springaicommunity.mcp.annotation.McpPrompt;
 
 /**
  * Utility class for adapting between McpPrompt annotations and McpSchema.Prompt objects.
  *
  * @author Christian Tzolov
  */
-public class PromptAdaptor {
+public class PromptAdapter {
 
-	private PromptAdaptor() {
+	private PromptAdapter() {
 	}
 
 	/**

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/ResourceAdapter.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/ResourceAdapter.java
@@ -1,16 +1,17 @@
 /*
 * Copyright 2025 - 2025 the original author or authors.
 */
-package org.springaicommunity.mcp.annotation;
+package org.springaicommunity.mcp.adapter;
 
 import io.modelcontextprotocol.spec.McpSchema;
+import org.springaicommunity.mcp.annotation.McpResource;
 
 /**
  * @author Christian Tzolov
  */
-public class ResourceAdaptor {
+public class ResourceAdapter {
 
-	private ResourceAdaptor() {
+	private ResourceAdapter() {
 	}
 
 	public static McpSchema.Resource asResource(McpResource mcpResource) {

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/complete/AbstractMcpCompleteMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/complete/AbstractMcpCompleteMethodCallback.java
@@ -9,11 +9,6 @@ import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springaicommunity.mcp.annotation.CompleteAdapter;
-import org.springaicommunity.mcp.annotation.McpComplete;
-import org.springaicommunity.mcp.annotation.McpMeta;
-import org.springaicommunity.mcp.annotation.McpProgressToken;
-
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CompleteReference;
 import io.modelcontextprotocol.spec.McpSchema.CompleteRequest;
@@ -21,6 +16,10 @@ import io.modelcontextprotocol.util.Assert;
 import io.modelcontextprotocol.util.DeafaultMcpUriTemplateManagerFactory;
 import io.modelcontextprotocol.util.McpUriTemplateManager;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
+import org.springaicommunity.mcp.adapter.CompleteAdapter;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.annotation.McpMeta;
+import org.springaicommunity.mcp.annotation.McpProgressToken;
 
 /**
  * Abstract base class for creating callbacks around complete methods.

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/AsyncMcpCompleteProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/AsyncMcpCompleteProvider.java
@@ -20,16 +20,15 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.CompleteAdapter;
-import org.springaicommunity.mcp.annotation.McpComplete;
-import org.springaicommunity.mcp.method.complete.AsyncMcpCompleteMethodCallback;
-
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
 import io.modelcontextprotocol.util.Assert;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.adapter.CompleteAdapter;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.method.complete.AsyncMcpCompleteMethodCallback;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/AsyncStatelessMcpCompleteProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/AsyncStatelessMcpCompleteProvider.java
@@ -21,18 +21,17 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.CompleteAdapter;
-import org.springaicommunity.mcp.annotation.McpComplete;
-import org.springaicommunity.mcp.method.complete.AsyncStatelessMcpCompleteMethodCallback;
-
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema.CompleteRequest;
 import io.modelcontextprotocol.spec.McpSchema.CompleteResult;
 import io.modelcontextprotocol.util.Assert;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.adapter.CompleteAdapter;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.method.complete.AsyncStatelessMcpCompleteMethodCallback;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/SyncMcpCompleteProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/SyncMcpCompleteProvider.java
@@ -20,12 +20,11 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.springaicommunity.mcp.annotation.CompleteAdapter;
-import org.springaicommunity.mcp.annotation.McpComplete;
-import org.springaicommunity.mcp.method.complete.SyncMcpCompleteMethodCallback;
-
 import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.util.Assert;
+import org.springaicommunity.mcp.adapter.CompleteAdapter;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.method.complete.SyncMcpCompleteMethodCallback;
 import reactor.core.publisher.Mono;
 
 /**

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/SyncStatelessMcpCompleteProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/SyncStatelessMcpCompleteProvider.java
@@ -21,17 +21,16 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.CompleteAdapter;
-import org.springaicommunity.mcp.annotation.McpComplete;
-import org.springaicommunity.mcp.method.complete.SyncStatelessMcpCompleteMethodCallback;
-
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema.CompleteRequest;
 import io.modelcontextprotocol.spec.McpSchema.CompleteResult;
 import io.modelcontextprotocol.util.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.adapter.CompleteAdapter;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.method.complete.SyncStatelessMcpCompleteMethodCallback;
 import reactor.core.publisher.Mono;
 
 /**

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/AsyncMcpPromptProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/AsyncMcpPromptProvider.java
@@ -21,18 +21,17 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.McpPrompt;
-import org.springaicommunity.mcp.annotation.PromptAdaptor;
-import org.springaicommunity.mcp.method.prompt.AsyncMcpPromptMethodCallback;
-
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncPromptSpecification;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.util.Assert;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.adapter.PromptAdapter;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.method.prompt.AsyncMcpPromptMethodCallback;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -75,7 +74,7 @@ public class AsyncMcpPromptProvider {
 						|| Publisher.class.isAssignableFrom(method.getReturnType()))
 				.map(mcpPromptMethod -> {
 					var promptAnnotation = mcpPromptMethod.getAnnotation(McpPrompt.class);
-					var mcpPrompt = PromptAdaptor.asPrompt(promptAnnotation, mcpPromptMethod);
+					var mcpPrompt = PromptAdapter.asPrompt(promptAnnotation, mcpPromptMethod);
 
 					BiFunction<McpAsyncServerExchange, GetPromptRequest, Mono<GetPromptResult>> methodCallback = AsyncMcpPromptMethodCallback
 						.builder()

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/AsyncStatelessMcpPromptProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/AsyncStatelessMcpPromptProvider.java
@@ -21,18 +21,17 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.McpPrompt;
-import org.springaicommunity.mcp.annotation.PromptAdaptor;
-import org.springaicommunity.mcp.method.prompt.AsyncStatelessMcpPromptMethodCallback;
-
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncPromptSpecification;
 import io.modelcontextprotocol.server.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.util.Assert;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.adapter.PromptAdapter;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.method.prompt.AsyncStatelessMcpPromptMethodCallback;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -75,7 +74,7 @@ public class AsyncStatelessMcpPromptProvider {
 						|| Publisher.class.isAssignableFrom(method.getReturnType()))
 				.map(mcpPromptMethod -> {
 					var promptAnnotation = mcpPromptMethod.getAnnotation(McpPrompt.class);
-					var mcpPrompt = PromptAdaptor.asPrompt(promptAnnotation, mcpPromptMethod);
+					var mcpPrompt = PromptAdapter.asPrompt(promptAnnotation, mcpPromptMethod);
 
 					BiFunction<McpTransportContext, GetPromptRequest, Mono<GetPromptResult>> methodCallback = AsyncStatelessMcpPromptMethodCallback
 						.builder()

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/SyncMcpPromptProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/SyncMcpPromptProvider.java
@@ -20,12 +20,11 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.springaicommunity.mcp.annotation.McpPrompt;
-import org.springaicommunity.mcp.annotation.PromptAdaptor;
-import org.springaicommunity.mcp.method.prompt.SyncMcpPromptMethodCallback;
-
 import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
 import io.modelcontextprotocol.util.Assert;
+import org.springaicommunity.mcp.adapter.PromptAdapter;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.method.prompt.SyncMcpPromptMethodCallback;
 import reactor.core.publisher.Mono;
 
 /**
@@ -47,7 +46,7 @@ public class SyncMcpPromptProvider {
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
 				.map(mcpPromptMethod -> {
 					var promptAnnotation = mcpPromptMethod.getAnnotation(McpPrompt.class);
-					var mcpPrompt = PromptAdaptor.asPrompt(promptAnnotation, mcpPromptMethod);
+					var mcpPrompt = PromptAdapter.asPrompt(promptAnnotation, mcpPromptMethod);
 
 					var methodCallback = SyncMcpPromptMethodCallback.builder()
 						.method(mcpPromptMethod)

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/SyncStatelessMcpPromptProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/SyncStatelessMcpPromptProvider.java
@@ -21,17 +21,16 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.McpPrompt;
-import org.springaicommunity.mcp.annotation.PromptAdaptor;
-import org.springaicommunity.mcp.method.prompt.SyncStatelessMcpPromptMethodCallback;
-
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncPromptSpecification;
 import io.modelcontextprotocol.server.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.util.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.adapter.PromptAdapter;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.method.prompt.SyncStatelessMcpPromptMethodCallback;
 import reactor.core.publisher.Mono;
 
 /**
@@ -71,7 +70,7 @@ public class SyncStatelessMcpPromptProvider {
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
 				.map(mcpPromptMethod -> {
 					var promptAnnotation = mcpPromptMethod.getAnnotation(McpPrompt.class);
-					var mcpPrompt = PromptAdaptor.asPrompt(promptAnnotation, mcpPromptMethod);
+					var mcpPrompt = PromptAdapter.asPrompt(promptAnnotation, mcpPromptMethod);
 
 					BiFunction<McpTransportContext, GetPromptRequest, GetPromptResult> methodCallback = SyncStatelessMcpPromptMethodCallback
 						.builder()

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/prompt/AsyncMcpPromptMethodCallbackExample.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/prompt/AsyncMcpPromptMethodCallbackExample.java
@@ -10,11 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
-import org.springaicommunity.mcp.annotation.McpArg;
-import org.springaicommunity.mcp.annotation.McpPrompt;
-import org.springaicommunity.mcp.annotation.PromptAdaptor;
-import org.springaicommunity.mcp.method.prompt.AsyncMcpPromptMethodCallback;
-
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
@@ -22,6 +17,9 @@ import io.modelcontextprotocol.spec.McpSchema.Prompt;
 import io.modelcontextprotocol.spec.McpSchema.PromptMessage;
 import io.modelcontextprotocol.spec.McpSchema.Role;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.springaicommunity.mcp.adapter.PromptAdapter;
+import org.springaicommunity.mcp.annotation.McpArg;
+import org.springaicommunity.mcp.annotation.McpPrompt;
 import reactor.core.publisher.Mono;
 
 /**
@@ -191,7 +189,7 @@ public class AsyncMcpPromptMethodCallbackExample {
 		McpPrompt promptAnnotation = asyncGreetingMethod.getAnnotation(McpPrompt.class);
 
 		// Convert the annotation to a Prompt object with argument information
-		Prompt prompt = PromptAdaptor.asPrompt(promptAnnotation, asyncGreetingMethod);
+		Prompt prompt = PromptAdapter.asPrompt(promptAnnotation, asyncGreetingMethod);
 
 		// Create the callback
 		BiFunction<McpAsyncServerExchange, GetPromptRequest, Mono<GetPromptResult>> callback = AsyncMcpPromptMethodCallback
@@ -235,7 +233,7 @@ public class AsyncMcpPromptMethodCallbackExample {
 		McpPrompt promptAnnotation = asyncStringMethod.getAnnotation(McpPrompt.class);
 
 		// Convert the annotation to a Prompt object with argument information
-		Prompt prompt = PromptAdaptor.asPrompt(promptAnnotation, asyncStringMethod);
+		Prompt prompt = PromptAdapter.asPrompt(promptAnnotation, asyncStringMethod);
 
 		// Create the callback
 		BiFunction<McpAsyncServerExchange, GetPromptRequest, Mono<GetPromptResult>> callback = AsyncMcpPromptMethodCallback
@@ -278,7 +276,7 @@ public class AsyncMcpPromptMethodCallbackExample {
 		McpPrompt promptAnnotation = asyncStringListMethod.getAnnotation(McpPrompt.class);
 
 		// Convert the annotation to a Prompt object with argument information
-		Prompt prompt = PromptAdaptor.asPrompt(promptAnnotation, asyncStringListMethod);
+		Prompt prompt = PromptAdapter.asPrompt(promptAnnotation, asyncStringListMethod);
 
 		// Create the callback
 		BiFunction<McpAsyncServerExchange, GetPromptRequest, Mono<GetPromptResult>> callback = AsyncMcpPromptMethodCallback

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/prompt/SyncMcpPromptMethodCallbackExample.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/prompt/SyncMcpPromptMethodCallbackExample.java
@@ -9,11 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
-import org.springaicommunity.mcp.annotation.McpArg;
-import org.springaicommunity.mcp.annotation.McpPrompt;
-import org.springaicommunity.mcp.annotation.PromptAdaptor;
-import org.springaicommunity.mcp.method.prompt.SyncMcpPromptMethodCallback;
-
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
@@ -21,6 +16,9 @@ import io.modelcontextprotocol.spec.McpSchema.Prompt;
 import io.modelcontextprotocol.spec.McpSchema.PromptMessage;
 import io.modelcontextprotocol.spec.McpSchema.Role;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.springaicommunity.mcp.adapter.PromptAdapter;
+import org.springaicommunity.mcp.annotation.McpArg;
+import org.springaicommunity.mcp.annotation.McpPrompt;
 
 /**
  * Example demonstrating how to use the SyncMcpPromptMethodCallback.
@@ -196,7 +194,7 @@ public class SyncMcpPromptMethodCallbackExample {
 		McpPrompt promptAnnotation = greetingMethod.getAnnotation(McpPrompt.class);
 
 		// Convert the annotation to a Prompt object with argument information
-		Prompt prompt = PromptAdaptor.asPrompt(promptAnnotation, greetingMethod);
+		Prompt prompt = PromptAdapter.asPrompt(promptAnnotation, greetingMethod);
 
 		// Create the callback
 		BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> callback = SyncMcpPromptMethodCallback
@@ -235,7 +233,7 @@ public class SyncMcpPromptMethodCallbackExample {
 		McpPrompt promptAnnotation = singleMessageMethod.getAnnotation(McpPrompt.class);
 
 		// Convert the annotation to a Prompt object with argument information
-		Prompt prompt = PromptAdaptor.asPrompt(promptAnnotation, singleMessageMethod);
+		Prompt prompt = PromptAdapter.asPrompt(promptAnnotation, singleMessageMethod);
 
 		// Create the callback
 		BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> callback = SyncMcpPromptMethodCallback
@@ -273,7 +271,7 @@ public class SyncMcpPromptMethodCallbackExample {
 		McpPrompt promptAnnotation = stringListMethod.getAnnotation(McpPrompt.class);
 
 		// Convert the annotation to a Prompt object with argument information
-		Prompt prompt = PromptAdaptor.asPrompt(promptAnnotation, stringListMethod);
+		Prompt prompt = PromptAdapter.asPrompt(promptAnnotation, stringListMethod);
 
 		// Create the callback
 		BiFunction<McpSyncServerExchange, GetPromptRequest, GetPromptResult> callback = SyncMcpPromptMethodCallback

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/AsyncMcpResourceMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/AsyncMcpResourceMethodCallbackTests.java
@@ -18,11 +18,10 @@ import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import io.modelcontextprotocol.util.McpUriTemplateManager;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
 import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.adapter.ResourceAdapter;
 import org.springaicommunity.mcp.annotation.McpMeta;
 import org.springaicommunity.mcp.annotation.McpProgressToken;
 import org.springaicommunity.mcp.annotation.McpResource;
-import org.springaicommunity.mcp.annotation.ResourceAdaptor;
-
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -276,7 +275,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -304,7 +303,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -332,7 +331,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -360,7 +359,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -388,7 +387,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -416,7 +415,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -442,7 +441,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -470,7 +469,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -499,7 +498,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -578,7 +577,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 		assertThatThrownBy(() -> AsyncMcpResourceMethodCallback.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(mockResourceAnnotation))
+			.resource(ResourceAdapter.asResource(mockResourceAnnotation))
 			.build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Method must have parameters for all URI variables");
 	}
@@ -592,7 +591,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -614,7 +613,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -649,7 +648,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.uriTemplateManagerFactory(new McpUriTemplateManagerFactory() {
 				public McpUriTemplateManager create(String uriTemplate) {
 					return mockUriTemplateManager;
@@ -677,7 +676,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -706,7 +705,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -736,7 +735,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -764,7 +763,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -794,7 +793,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -823,7 +822,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -853,7 +852,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -885,7 +884,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -914,7 +913,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -943,7 +942,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -971,7 +970,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -1001,7 +1000,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -1030,7 +1029,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -1060,7 +1059,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
@@ -1092,7 +1091,7 @@ public class AsyncMcpResourceMethodCallbackTests {
 		assertThatThrownBy(() -> AsyncMcpResourceMethodCallback.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Method cannot have more than one McpMeta parameter");
 	}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/AsyncStatelessMcpResourceMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/AsyncStatelessMcpResourceMethodCallbackTests.java
@@ -18,11 +18,10 @@ import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import io.modelcontextprotocol.util.McpUriTemplateManager;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
 import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.adapter.ResourceAdapter;
 import org.springaicommunity.mcp.annotation.McpMeta;
 import org.springaicommunity.mcp.annotation.McpProgressToken;
 import org.springaicommunity.mcp.annotation.McpResource;
-import org.springaicommunity.mcp.annotation.ResourceAdaptor;
-
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -232,7 +231,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -260,7 +259,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -288,7 +287,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -316,7 +315,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -344,7 +343,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -372,7 +371,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -399,7 +398,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -427,7 +426,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -456,7 +455,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -539,7 +538,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 		assertThatThrownBy(() -> AsyncStatelessMcpResourceMethodCallback.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(mockResourceAnnotation))
+			.resource(ResourceAdapter.asResource(mockResourceAnnotation))
 			.build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Method must have parameters for all URI variables");
 	}
@@ -554,7 +553,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -577,7 +576,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -612,7 +611,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.uriTemplateManagerFactory(new McpUriTemplateManagerFactory() {
 				public McpUriTemplateManager create(String uriTemplate) {
 					return mockUriTemplateManager;
@@ -637,7 +636,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 		AsyncStatelessMcpResourceMethodCallback callback = AsyncStatelessMcpResourceMethodCallback.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		// Test that McpTransportContext is recognized as context type
@@ -681,7 +680,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -707,7 +706,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -734,7 +733,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -761,7 +760,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -787,7 +786,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -815,7 +814,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -842,7 +841,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -870,7 +869,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -902,7 +901,7 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 		assertThatThrownBy(() -> AsyncStatelessMcpResourceMethodCallback.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Method cannot have more than one McpMeta parameter");
 	}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/McpResourceUriValidationTest.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/McpResourceUriValidationTest.java
@@ -7,12 +7,10 @@ package org.springaicommunity.mcp.method.resource;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import org.springaicommunity.mcp.annotation.McpResource;
-import org.springaicommunity.mcp.annotation.ResourceAdaptor;
-import org.springaicommunity.mcp.method.resource.SyncMcpResourceMethodCallback;
-
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
+import org.springaicommunity.mcp.adapter.ResourceAdapter;
+import org.springaicommunity.mcp.annotation.McpResource;
 
 /**
  * Simple test to verify that McpResourceMethodCallback requires a non-empty URI in the
@@ -108,7 +106,7 @@ public class McpResourceUriValidationTest {
 				SyncMcpResourceMethodCallback.builder()
 					.method(validMethod)
 					.bean(provider)
-					.resource(ResourceAdaptor.asResource(validAnnotation))
+					.resource(ResourceAdapter.asResource(validAnnotation))
 					.build();
 				System.out.println("  PASS: Successfully created callback with valid URI");
 			}
@@ -122,7 +120,7 @@ public class McpResourceUriValidationTest {
 				SyncMcpResourceMethodCallback.builder()
 					.method(validMethod)
 					.bean(provider)
-					.resource(ResourceAdaptor.asResource(createMockResourceWithEmptyUri()))
+					.resource(ResourceAdapter.asResource(createMockResourceWithEmptyUri()))
 					.build();
 				System.out.println("  FAIL: Should have thrown exception for empty URI");
 			}
@@ -136,7 +134,7 @@ public class McpResourceUriValidationTest {
 				SyncMcpResourceMethodCallback.builder()
 					.method(validMethod)
 					.bean(provider)
-					.resource(ResourceAdaptor.asResource(createMockResourceWithValidUri()))
+					.resource(ResourceAdapter.asResource(createMockResourceWithValidUri()))
 					.build();
 				System.out.println("  PASS: Successfully created callback with valid URI");
 			}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/SyncMcpResourceMethodCallbackExample.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/SyncMcpResourceMethodCallbackExample.java
@@ -18,11 +18,9 @@ import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
-
 import org.mockito.Mockito;
+import org.springaicommunity.mcp.adapter.ResourceAdapter;
 import org.springaicommunity.mcp.annotation.McpResource;
-import org.springaicommunity.mcp.annotation.ResourceAdaptor;
-import org.springaicommunity.mcp.method.resource.SyncMcpResourceMethodCallback;
 
 /**
  * Example demonstrating how to use the {@link SyncMcpResourceMethodCallback} with
@@ -256,7 +254,7 @@ public class SyncMcpResourceMethodCallbackExample {
 						.builder()
 						.method(method)
 						.bean(profileProvider)
-						.resource(ResourceAdaptor.asResource(resourceAnnotation))
+						.resource(ResourceAdapter.asResource(resourceAnnotation))
 						.build();
 
 					// Register the callback with the URI pattern from the annotation

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/SyncMcpResourceMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/SyncMcpResourceMethodCallbackTests.java
@@ -4,20 +4,9 @@
 
 package org.springaicommunity.mcp.method.resource;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.function.BiFunction;
-
-import org.junit.jupiter.api.Test;
-import org.springaicommunity.mcp.annotation.McpMeta;
-import org.springaicommunity.mcp.annotation.McpProgressToken;
-import org.springaicommunity.mcp.annotation.McpResource;
-import org.springaicommunity.mcp.annotation.ResourceAdaptor;
 
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
@@ -25,6 +14,16 @@ import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.adapter.ResourceAdapter;
+import org.springaicommunity.mcp.annotation.McpMeta;
+import org.springaicommunity.mcp.annotation.McpProgressToken;
+import org.springaicommunity.mcp.annotation.McpResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link SyncMcpResourceMethodCallback}.
@@ -246,7 +245,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -272,7 +271,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -296,7 +295,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -321,7 +320,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -347,7 +346,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -371,7 +370,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -395,7 +394,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -421,7 +420,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -445,7 +444,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -508,7 +507,7 @@ public class SyncMcpResourceMethodCallbackTests {
 		assertThatThrownBy(() -> SyncMcpResourceMethodCallback.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(mockResourceAnnotation))
+			.resource(ResourceAdapter.asResource(mockResourceAnnotation))
 			.build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Method must have parameters for all URI variables");
 	}
@@ -523,7 +522,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -549,7 +548,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -576,7 +575,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -606,7 +605,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -702,7 +701,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -729,7 +728,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -755,7 +754,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -783,7 +782,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -810,7 +809,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -838,7 +837,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -868,7 +867,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -896,7 +895,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -923,7 +922,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -949,7 +948,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -977,7 +976,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -1004,7 +1003,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -1032,7 +1031,7 @@ public class SyncMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
@@ -1060,7 +1059,7 @@ public class SyncMcpResourceMethodCallbackTests {
 		assertThatThrownBy(() -> SyncMcpResourceMethodCallback.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Method cannot have more than one McpMeta parameter");
 	}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/SyncStatelessMcpResourceMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/SyncStatelessMcpResourceMethodCallbackTests.java
@@ -4,21 +4,10 @@
 
 package org.springaicommunity.mcp.method.resource;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
-
-import org.junit.jupiter.api.Test;
-import org.springaicommunity.mcp.annotation.McpMeta;
-import org.springaicommunity.mcp.annotation.McpProgressToken;
-import org.springaicommunity.mcp.annotation.McpResource;
-import org.springaicommunity.mcp.annotation.ResourceAdaptor;
 
 import io.modelcontextprotocol.server.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
@@ -26,6 +15,16 @@ import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.adapter.ResourceAdapter;
+import org.springaicommunity.mcp.annotation.McpMeta;
+import org.springaicommunity.mcp.annotation.McpProgressToken;
+import org.springaicommunity.mcp.annotation.McpResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link SyncStatelessMcpResourceMethodCallback}.
@@ -212,7 +211,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -238,7 +237,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -262,7 +261,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -287,7 +286,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -313,7 +312,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -337,7 +336,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -361,7 +360,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -387,7 +386,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -411,7 +410,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -436,7 +435,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -462,7 +461,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -489,7 +488,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -519,7 +518,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -586,7 +585,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 		assertThatThrownBy(() -> SyncStatelessMcpResourceMethodCallback.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(mockResourceAnnotation))
+			.resource(ResourceAdapter.asResource(mockResourceAnnotation))
 			.build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Method must have parameters for all URI variables");
 	}
@@ -600,7 +599,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -616,7 +615,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 		SyncStatelessMcpResourceMethodCallback callback = SyncStatelessMcpResourceMethodCallback.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		// Test that McpTransportContext is recognized as exchange type
@@ -671,7 +670,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -695,7 +694,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -722,7 +721,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -748,7 +747,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -776,7 +775,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(resourceAnnotation))
+			.resource(ResourceAdapter.asResource(resourceAnnotation))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -803,7 +802,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -830,7 +829,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build();
 
 		McpTransportContext context = mock(McpTransportContext.class);
@@ -860,7 +859,7 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 		assertThatThrownBy(() -> SyncStatelessMcpResourceMethodCallback.builder()
 			.method(method)
 			.bean(provider)
-			.resource(ResourceAdaptor.asResource(createMockMcpResource()))
+			.resource(ResourceAdapter.asResource(createMockMcpResource()))
 			.build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Method cannot have more than one McpMeta parameter");
 	}


### PR DESCRIPTION
- Move CompleteAdapter, PromptAdapter, and ResourceAdapter from org.springaicommunity.mcp.annotation to org.springaicommunity.mcp.adapter package
- Fix class name typos: PromptAdaptor → PromptAdapter, ResourceAdaptor → ResourceAdapter
- Update all import statements throughout the codebase to reflect the new package structure
- Reorganize imports for better code organization and consistency

This refactoring improves package organization by separating adapter utilities from annotation classes while maintaining the same public API.