### PR TITLE
feat: add deterministic method sorting to all MCP providers

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/prompt/AsyncMcpPromptListChangedProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/prompt/AsyncMcpPromptListChangedProvider.java
@@ -84,6 +84,7 @@ public class AsyncMcpPromptListChangedProvider {
 				.filter(method -> method.isAnnotationPresent(McpPromptListChanged.class))
 				.filter(method -> method.getReturnType() == void.class
 						|| Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpPromptListChangedConsumerMethod -> {
 					var promptListChangedAnnotation = mcpPromptListChangedConsumerMethod
 						.getAnnotation(McpPromptListChanged.class);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/prompt/SyncMcpPromptListChangedProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/prompt/SyncMcpPromptListChangedProvider.java
@@ -82,6 +82,7 @@ public class SyncMcpPromptListChangedProvider {
 			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
 				.filter(method -> method.isAnnotationPresent(McpPromptListChanged.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpPromptListChangedConsumerMethod -> {
 					var promptListChangedAnnotation = mcpPromptListChangedConsumerMethod
 						.getAnnotation(McpPromptListChanged.class);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/resource/AsyncMcpResourceListChangedProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/resource/AsyncMcpResourceListChangedProvider.java
@@ -84,6 +84,7 @@ public class AsyncMcpResourceListChangedProvider {
 				.filter(method -> method.isAnnotationPresent(McpResourceListChanged.class))
 				.filter(method -> method.getReturnType() == void.class
 						|| Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpResourceListChangedConsumerMethod -> {
 					var resourceListChangedAnnotation = mcpResourceListChangedConsumerMethod
 						.getAnnotation(McpResourceListChanged.class);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/resource/SyncMcpResourceListChangedProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/resource/SyncMcpResourceListChangedProvider.java
@@ -82,6 +82,7 @@ public class SyncMcpResourceListChangedProvider {
 			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
 				.filter(method -> method.isAnnotationPresent(McpResourceListChanged.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpResourceListChangedConsumerMethod -> {
 					var resourceListChangedAnnotation = mcpResourceListChangedConsumerMethod
 						.getAnnotation(McpResourceListChanged.class);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/tool/AsyncMcpToolListChangedProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/tool/AsyncMcpToolListChangedProvider.java
@@ -83,6 +83,7 @@ public class AsyncMcpToolListChangedProvider {
 				.filter(method -> method.isAnnotationPresent(McpToolListChanged.class))
 				.filter(method -> method.getReturnType() == void.class
 						|| Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolListChangedConsumerMethod -> {
 					var toolListChangedAnnotation = mcpToolListChangedConsumerMethod
 						.getAnnotation(McpToolListChanged.class);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/tool/SyncMcpToolListChangedProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/changed/tool/SyncMcpToolListChangedProvider.java
@@ -81,6 +81,7 @@ public class SyncMcpToolListChangedProvider {
 			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
 				.filter(method -> method.isAnnotationPresent(McpToolListChanged.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolListChangedConsumerMethod -> {
 					var toolListChangedAnnotation = mcpToolListChangedConsumerMethod
 						.getAnnotation(McpToolListChanged.class);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/AsyncMcpCompleteProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/AsyncMcpCompleteProvider.java
@@ -69,6 +69,7 @@ public class AsyncMcpCompleteProvider {
 				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
 						|| Flux.class.isAssignableFrom(method.getReturnType())
 						|| Publisher.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpCompleteMethod -> {
 					var completeAnnotation = mcpCompleteMethod.getAnnotation(McpComplete.class);
 					var completeRef = CompleteAdapter.asCompleteReference(completeAnnotation, mcpCompleteMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/AsyncStatelessMcpCompleteProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/AsyncStatelessMcpCompleteProvider.java
@@ -72,6 +72,7 @@ public class AsyncStatelessMcpCompleteProvider {
 				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
 						|| Flux.class.isAssignableFrom(method.getReturnType())
 						|| Publisher.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpCompleteMethod -> {
 					var completeAnnotation = mcpCompleteMethod.getAnnotation(McpComplete.class);
 					var completeRef = CompleteAdapter.asCompleteReference(completeAnnotation, mcpCompleteMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/SyncMcpCompleteProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/SyncMcpCompleteProvider.java
@@ -44,6 +44,7 @@ public class SyncMcpCompleteProvider {
 			.map(completeObject -> Stream.of(doGetClassMethods(completeObject))
 				.filter(method -> method.isAnnotationPresent(McpComplete.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpCompleteMethod -> {
 					var completeAnnotation = mcpCompleteMethod.getAnnotation(McpComplete.class);
 					var completeRef = CompleteAdapter.asCompleteReference(completeAnnotation, mcpCompleteMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/SyncStatelessMcpCompleteProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/SyncStatelessMcpCompleteProvider.java
@@ -68,6 +68,7 @@ public class SyncStatelessMcpCompleteProvider {
 			.map(completeObject -> Stream.of(doGetClassMethods(completeObject))
 				.filter(method -> method.isAnnotationPresent(McpComplete.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpCompleteMethod -> {
 					var completeAnnotation = mcpCompleteMethod.getAnnotation(McpComplete.class);
 					var completeRef = CompleteAdapter.asCompleteReference(completeAnnotation, mcpCompleteMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/elicitation/AsyncMcpElicitationProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/elicitation/AsyncMcpElicitationProvider.java
@@ -91,6 +91,7 @@ public class AsyncMcpElicitationProvider {
 						&& ElicitRequest.class.isAssignableFrom(method.getParameterTypes()[0]))
 				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
 						|| ElicitResult.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpElicitationMethod -> {
 					var elicitationAnnotation = mcpElicitationMethod.getAnnotation(McpElicitation.class);
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/elicitation/SyncMcpElicitationProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/elicitation/SyncMcpElicitationProvider.java
@@ -91,6 +91,7 @@ public class SyncMcpElicitationProvider {
 				.filter(method -> ElicitResult.class.isAssignableFrom(method.getReturnType()))
 				.filter(method -> method.getParameterCount() == 1
 						&& ElicitRequest.class.isAssignableFrom(method.getParameterTypes()[0]))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpElicitationMethod -> {
 					var elicitationAnnotation = mcpElicitationMethod.getAnnotation(McpElicitation.class);
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/logging/AsyncMcpLoggingProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/logging/AsyncMcpLoggingProvider.java
@@ -78,8 +78,9 @@ public class AsyncMcpLoggingProvider {
 	public List<AsyncLoggingSpecification> getLoggingSpecifications() {
 
 		List<AsyncLoggingSpecification> loggingConsumers = this.loggingConsumerObjects.stream()
-			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
+			.map(consumerObject -> Stream.of(this.doGetClassMethods(consumerObject))
 				.filter(method -> method.isAnnotationPresent(McpLogging.class))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpLoggingConsumerMethod -> {
 					var loggingConsumerAnnotation = mcpLoggingConsumerMethod.getAnnotation(McpLogging.class);
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/logging/SyncMcpLogginProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/logging/SyncMcpLogginProvider.java
@@ -81,6 +81,7 @@ public class SyncMcpLogginProvider {
 			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
 				.filter(method -> method.isAnnotationPresent(McpLogging.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpLoggingConsumerMethod -> {
 					var loggingConsumerAnnotation = mcpLoggingConsumerMethod.getAnnotation(McpLogging.class);
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/progress/AsyncMcpProgressProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/progress/AsyncMcpProgressProvider.java
@@ -97,6 +97,7 @@ public class AsyncMcpProgressProvider {
 					}
 					return false;
 				})
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpProgressMethod -> {
 					var progressAnnotation = mcpProgressMethod.getAnnotation(McpProgress.class);
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/progress/SyncMcpProgressProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/progress/SyncMcpProgressProvider.java
@@ -82,6 +82,7 @@ public class SyncMcpProgressProvider {
 				.filter(method -> method.getReturnType() == void.class) // Only void
 																		// return type is
 																		// valid for sync
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpProgressMethod -> {
 					var progressAnnotation = mcpProgressMethod.getAnnotation(McpProgress.class);
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/AsyncMcpPromptProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/AsyncMcpPromptProvider.java
@@ -72,6 +72,7 @@ public class AsyncMcpPromptProvider {
 				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
 						|| Flux.class.isAssignableFrom(method.getReturnType())
 						|| Publisher.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpPromptMethod -> {
 					var promptAnnotation = mcpPromptMethod.getAnnotation(McpPrompt.class);
 					var mcpPrompt = PromptAdapter.asPrompt(promptAnnotation, mcpPromptMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/AsyncStatelessMcpPromptProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/AsyncStatelessMcpPromptProvider.java
@@ -72,6 +72,7 @@ public class AsyncStatelessMcpPromptProvider {
 				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
 						|| Flux.class.isAssignableFrom(method.getReturnType())
 						|| Publisher.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpPromptMethod -> {
 					var promptAnnotation = mcpPromptMethod.getAnnotation(McpPrompt.class);
 					var mcpPrompt = PromptAdapter.asPrompt(promptAnnotation, mcpPromptMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/SyncMcpPromptProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/SyncMcpPromptProvider.java
@@ -44,6 +44,7 @@ public class SyncMcpPromptProvider {
 			.map(resourceObject -> Stream.of(doGetClassMethods(resourceObject))
 				.filter(method -> method.isAnnotationPresent(McpPrompt.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpPromptMethod -> {
 					var promptAnnotation = mcpPromptMethod.getAnnotation(McpPrompt.class);
 					var mcpPrompt = PromptAdapter.asPrompt(promptAnnotation, mcpPromptMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/SyncStatelessMcpPromptProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/SyncStatelessMcpPromptProvider.java
@@ -68,6 +68,7 @@ public class SyncStatelessMcpPromptProvider {
 			.map(promptObject -> Stream.of(doGetClassMethods(promptObject))
 				.filter(method -> method.isAnnotationPresent(McpPrompt.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpPromptMethod -> {
 					var promptAnnotation = mcpPromptMethod.getAnnotation(McpPrompt.class);
 					var mcpPrompt = PromptAdapter.asPrompt(promptAnnotation, mcpPromptMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncMcpResourceProvider.java
@@ -73,6 +73,7 @@ public class AsyncMcpResourceProvider {
 				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
 						|| Flux.class.isAssignableFrom(method.getReturnType())
 						|| Publisher.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpResourceMethod -> {
 
 					var resourceAnnotation = doGetMcpResourceAnnotation(mcpResourceMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProvider.java
@@ -73,6 +73,7 @@ public class AsyncStatelessMcpResourceProvider {
 				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
 						|| Flux.class.isAssignableFrom(method.getReturnType())
 						|| Publisher.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpResourceMethod -> {
 
 					var resourceAnnotation = doGetMcpResourceAnnotation(mcpResourceMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncMcpResourceProvider.java
@@ -45,6 +45,7 @@ public class SyncMcpResourceProvider {
 			.map(resourceObject -> Stream.of(this.doGetClassMethods(resourceObject))
 				.filter(resourceMethod -> resourceMethod.isAnnotationPresent(McpResource.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpResourceMethod -> {
 					var resourceAnnotation = mcpResourceMethod.getAnnotation(McpResource.class);
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProvider.java
@@ -69,6 +69,7 @@ public class SyncStatelessMcpResourceProvider {
 			.map(resourceObject -> Stream.of(doGetClassMethods(resourceObject))
 				.filter(method -> method.isAnnotationPresent(McpResource.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpResourceMethod -> {
 
 					var resourceAnnotation = doGetMcpResourceAnnotation(mcpResourceMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/sampling/AsyncMcpSamplingProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/sampling/AsyncMcpSamplingProvider.java
@@ -91,6 +91,7 @@ public class AsyncMcpSamplingProvider {
 						&& CreateMessageRequest.class.isAssignableFrom(method.getParameterTypes()[0]))
 				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
 						|| CreateMessageResult.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpSamplingMethod -> {
 					var samplingAnnotation = mcpSamplingMethod.getAnnotation(McpSampling.class);
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/sampling/SyncMcpSamplingProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/sampling/SyncMcpSamplingProvider.java
@@ -91,6 +91,7 @@ public class SyncMcpSamplingProvider {
 				.filter(method -> CreateMessageResult.class.isAssignableFrom(method.getReturnType()))
 				.filter(method -> method.getParameterCount() == 1
 						&& CreateMessageRequest.class.isAssignableFrom(method.getParameterTypes()[0]))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpSamplingMethod -> {
 					var samplingAnnotation = mcpSamplingMethod.getAnnotation(McpSampling.class);
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncMcpToolProvider.java
@@ -73,6 +73,7 @@ public class AsyncMcpToolProvider {
 				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
 						|| Flux.class.isAssignableFrom(method.getReturnType())
 						|| Publisher.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolMethod -> {
 
 					var toolJavaAnnotation = doGetMcpToolAnnotation(mcpToolMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -77,6 +77,7 @@ public class AsyncStatelessMcpToolProvider {
 				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
 						|| Flux.class.isAssignableFrom(method.getReturnType())
 						|| Publisher.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolMethod -> {
 
 					var toolJavaAnnotation = doGetMcpToolAnnotation(mcpToolMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncMcpToolProvider.java
@@ -68,6 +68,7 @@ public class SyncMcpToolProvider {
 			.map(toolObject -> Stream.of(doGetClassMethods(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolMethod -> {
 
 					McpTool toolJavaAnnotation = doGetMcpToolAnnotation(mcpToolMethod);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProvider.java
@@ -72,6 +72,7 @@ public class SyncStatelessMcpToolProvider {
 			.map(toolObject -> Stream.of(doGetClassMethods(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
 				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolMethod -> {
 
 					var toolJavaAnnotation = doGetMcpToolAnnotation(mcpToolMethod);

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/logging/SyncMcpLoggingProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/logging/SyncMcpLoggingProviderTests.java
@@ -38,11 +38,13 @@ public class SyncMcpLoggingProviderTests {
 
 		@McpLogging(clients = "test-client")
 		public void handleLoggingMessage(LoggingMessageNotification notification) {
+			System.out.println("1");
 			this.lastNotification = notification;
 		}
 
 		@McpLogging(clients = "test-client")
 		public void handleLoggingMessageWithParams(LoggingLevel level, String logger, String data) {
+			System.out.println("2");
 			this.lastLevel = level;
 			this.lastLogger = logger;
 			this.lastData = data;


### PR DESCRIPTION
- Sort annotated methods by name in all provider classes to ensure consistent processing order
- Apply sorting to 32 provider classes across tool, resource, prompt, complete, progress, logging, sampling, and elicitation providers
- Include both sync/async and stateless variants
- Add test infrastructure improvements with CountDownLatch for better async testing
- Ensures deterministic behavior across different JVM runs and environments

This change improves reliability by eliminating non-deterministic method ordering that could lead to inconsistent behavior in MCP server implementations.