### PR TITLE
Add support for MCP Prompt Title

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/PromptAdapter.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/PromptAdapter.java
@@ -29,7 +29,7 @@ public class PromptAdapter {
 	 * @return The corresponding McpSchema.Prompt object
 	 */
 	public static McpSchema.Prompt asPrompt(McpPrompt mcpPrompt) {
-		return new McpSchema.Prompt(mcpPrompt.name(), mcpPrompt.description(), List.of());
+		return new McpSchema.Prompt(mcpPrompt.name(), mcpPrompt.title(), mcpPrompt.description(), List.of());
 	}
 
 	/**
@@ -41,7 +41,7 @@ public class PromptAdapter {
 	 */
 	public static McpSchema.Prompt asPrompt(McpPrompt mcpPrompt, Method method) {
 		List<McpSchema.PromptArgument> arguments = extractPromptArguments(method);
-		return new McpSchema.Prompt(getName(mcpPrompt, method), mcpPrompt.description(), arguments);
+		return new McpSchema.Prompt(getName(mcpPrompt, method), mcpPrompt.title(), mcpPrompt.description(), arguments);
 	}
 
 	private static String getName(McpPrompt promptAnnotation, Method method) {

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpPrompt.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpPrompt.java
@@ -21,15 +21,17 @@ import java.lang.annotation.Target;
 public @interface McpPrompt {
 
 	/**
-	 * A human-readable name for this resource. This can be used by clients to populate UI
-	 * elements.
+	 * Unique identifier for the prompt
 	 */
 	String name() default "";
 
 	/**
-	 * A description of what this resource represents. This can be used by clients to
-	 * improve the LLM's understanding of available resources. It can be thought of like a
-	 * "hint" to the model.
+	 * Optional human-readable name of the prompt for display purposes.
+	 */
+	String title() default "";
+
+	/**
+	 * Optional human-readable description.
 	 */
 	String description() default "";
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/prompt/SyncMcpPromptProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/prompt/SyncMcpPromptProviderTests.java
@@ -113,6 +113,29 @@ public class SyncMcpPromptProviderTests {
 	}
 
 	@Test
+	void testGetPromptSpecificationsWithTitle() {
+		class PromptWithTitle {
+
+			@McpPrompt(name = "prompt-name", title = "Custom Title for UI", description = "Custom Titled prompt")
+			public GetPromptResult methodWithDifferentName() {
+				return new GetPromptResult("Custom prompt result",
+						List.of(new PromptMessage(Role.ASSISTANT, new TextContent("Custom prompt content"))));
+			}
+
+		}
+
+		PromptWithTitle promptObject = new PromptWithTitle();
+		SyncMcpPromptProvider provider = new SyncMcpPromptProvider(List.of(promptObject));
+
+		List<SyncPromptSpecification> promptSpecs = provider.getPromptSpecifications();
+
+		assertThat(promptSpecs).hasSize(1);
+		assertThat(promptSpecs.get(0).prompt().name()).isEqualTo("prompt-name");
+		assertThat(promptSpecs.get(0).prompt().title()).isEqualTo("Custom Title for UI");
+		assertThat(promptSpecs.get(0).prompt().description()).isEqualTo("Custom Titled prompt");
+	}
+
+	@Test
 	void testGetPromptSpecificationsWithDefaultPromptName() {
 		class DefaultNamePrompt {
 


### PR DESCRIPTION
## Pull Request Intention
This is to support the latest specification of [MCP Prompt](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#prompt)

## What changes
- Java doc for the prompt field to follow MCP Doc
- Adding `title` support and mapper to `McpSchema.Prompt`