### PR TITLE
Fix MCP toolcall returning list values

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractSyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractSyncMcpToolMethodCallback.java
@@ -19,7 +19,9 @@ package org.springaicommunity.mcp.method.tool;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.springaicommunity.mcp.annotation.McpMeta;
@@ -41,6 +43,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
  * @param <T> The type of the context parameter (e.g., McpTransportContext or
  * McpSyncServerExchange)
  * @author Christian Tzolov
+ * @author Ilayaperumal Gopinathan
  */
 public abstract class AbstractSyncMcpToolMethodCallback<T> {
 
@@ -156,9 +159,15 @@ public abstract class AbstractSyncMcpToolMethodCallback<T> {
 			return CallToolResult.builder().addTextContent(JsonParser.toJson("Done")).build();
 		}
 		else if (this.returnMode == ReturnMode.STRUCTURED) {
-			String jsonOutput = JsonParser.toJson(result);
-			Map<String, Object> structuredOutput = JsonParser.fromJson(jsonOutput, MAP_TYPE_REFERENCE);
-			return CallToolResult.builder().structuredContent(structuredOutput).build();
+			if (result instanceof List<?>) {
+				List<String> texts = ((List<?>) result).stream().map(String::valueOf).collect(Collectors.toList());
+				return CallToolResult.builder().textContent(texts).build();
+			}
+			else {
+				String jsonOutput = JsonParser.toJson(result);
+				Map<String, Object> structuredOutput = JsonParser.fromJson(jsonOutput, MAP_TYPE_REFERENCE);
+				return CallToolResult.builder().structuredContent(structuredOutput).build();
+			}
 		}
 
 		// Default to text output

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/SyncMcpToolMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/SyncMcpToolMethodCallbackTests.java
@@ -106,6 +106,11 @@ public class SyncMcpToolMethodCallbackTests {
 			return new TestObject(name, value);
 		}
 
+		@McpTool(name = "return-list-tool", description = "Tool that returns a list")
+		public List<String> returnListTool() {
+			return List.of("this", "is", "a", "test");
+		}
+
 	}
 
 	public static class TestObject {
@@ -505,6 +510,25 @@ public class SyncMcpToolMethodCallbackTests {
 		assertThat(result.structuredContent()).isNotNull();
 		assertThat(result.structuredContent()).containsEntry("name", "test");
 		assertThat(result.structuredContent()).containsEntry("value", 42);
+	}
+
+	@Test
+	public void testToolReturningList() throws Exception {
+		TestToolProvider provider = new TestToolProvider();
+		Method method = TestToolProvider.class.getMethod("returnListTool", null);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.STRUCTURED, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("return-list-tool", Map.of());
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).isNotEmpty();
+		result.content().forEach(textContent -> {
+			assertThat(((TextContent) textContent).text()).containsAnyOf("this", "is", "a", "test");
+		});
 	}
 
 }


### PR DESCRIPTION
  - When the MCP toolcall method returns list of values, the returned content needs to be converted as list of text content values (after converting the value to String type).
  - Add test to verify this behaviour