### PR TITLE
feat: improve output schema generation and return type handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,38 @@ public class CalculatorToolProvider {
 }
 ```
 
+#### Output Schema Generation
+
+The `@McpTool` annotation includes a `generateOutputSchema` attribute that controls whether output schemas are automatically generated for tool methods:
+
+```java
+@McpTool(name = "calculate", 
+         description = "Perform calculation",
+         generateOutputSchema = true)  // Explicitly enable output schema generation
+public CalculationResult calculate(double value) {
+    return new CalculationResult(value * 2, "doubled");
+}
+
+@McpTool(name = "simple-tool", 
+         description = "Simple tool without output schema")  // Default: no output schema
+public String simpleTool(String input) {
+    return "Processed: " + input;
+}
+```
+
+**Output Schema Behavior:**
+- **Default**: `generateOutputSchema = false` - No output schema is automatically generated
+- **When enabled**: `generateOutputSchema = true` - Output schema is generated for complex return types
+- **Primitive types**: No output schema is generated regardless of the setting (String, int, boolean, etc.)
+- **Void types**: No output schema is generated
+- **Complex types**: Output schema is generated only when explicitly enabled
+
+**Output Serialization:**
+- **String return types**: Returned directly as text content without JSON serialization
+- **Complex objects**: Serialized to JSON for text content
+- **Null values**: Returned as "null" text content
+- **Void methods**: Return "Done" as text content
+
 #### Tool Title Attribute
 
 The `@McpTool` annotation supports a `title` attribute that provides a human-readable display name for tools. This is intended for UI and end-user contexts, optimized to be easily understood even by those unfamiliar with domain-specific terminology.

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpTool.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpTool.java
@@ -34,9 +34,9 @@ public @interface McpTool {
 
 	/**
 	 * If true, the tool will generate an output schema for non-primitive output types. If
-	 * false, the tool will not generate an output schema.
+	 * false, the tool will not automatically generate an output schema.
 	 */
-	boolean generateOutputSchema() default true;
+	boolean generateOutputSchema() default false;
 
 	/**
 	 * Intended for UI and end-user contexts — optimized to be human-readable and easily

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/JsonSchemaGenerator.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/JsonSchemaGenerator.java
@@ -64,6 +64,8 @@ public class JsonSchemaGenerator {
 
 	private static final Map<Class<?>, String> classSchemaCache = new ConcurrentReferenceHashMap<>(256);
 
+	private static final Map<Type, String> typeSchemaCache = new ConcurrentReferenceHashMap<>(256);
+
 	/*
 	 * Initialize JSON Schema generators.
 	 */
@@ -185,6 +187,23 @@ public class JsonSchemaGenerator {
 
 		SchemaGenerator generator = new SchemaGenerator(config);
 		JsonNode jsonSchema = generator.generateSchema(clazz);
+		return jsonSchema.toPrettyString();
+	}
+
+	public static String generateFromType(Type type) {
+		Assert.notNull(type, "type cannot be null");
+		return typeSchemaCache.computeIfAbsent(type, JsonSchemaGenerator::internalGenerateFromType);
+	}
+
+	private static String internalGenerateFromType(Type type) {
+		SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12,
+				OptionPreset.PLAIN_JSON);
+		SchemaGeneratorConfig config = configBuilder.with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
+			.without(Option.FLATTENED_ENUMS_FROM_TOSTRING)
+			.build();
+
+		SchemaGenerator generator = new SchemaGenerator(config);
+		JsonNode jsonSchema = generator.generateSchema(type);
 		return jsonSchema.toPrettyString();
 	}
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -114,7 +114,6 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 					// Output schema is not generated for primitive types, void,
 					// CallToolResult, simple value types (String, etc.)
 					// or if generateOutputSchema attribute is set to false.
-
 					if (toolJavaAnnotation.generateOutputSchema()
 							&& !ReactiveUtils.isReactiveReturnTypeOfVoid(mcpToolMethod)
 							&& !ReactiveUtils.isReactiveReturnTypeOfCallToolResult(mcpToolMethod)) {
@@ -124,8 +123,7 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 									: null;
 							if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 									&& !ClassUtils.isSimpleValueType(methodReturnType)) {
-								toolBuilder
-									.outputSchema(JsonSchemaGenerator.generateFromClass((Class<?>) typeArgument));
+								toolBuilder.outputSchema(JsonSchemaGenerator.generateFromType(typeArgument));
 							}
 						});
 					}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncMcpToolProvider.java
@@ -116,7 +116,8 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 							&& methodReturnType != void.class && !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 							&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 
-						toolBuilder.outputSchema(JsonSchemaGenerator.generateFromClass(methodReturnType));
+						toolBuilder
+							.outputSchema(JsonSchemaGenerator.generateFromType(mcpToolMethod.getGenericReturnType()));
 					}
 
 					var tool = toolBuilder.build();

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProvider.java
@@ -119,7 +119,8 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 							&& methodReturnType != void.class && !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 							&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 
-						toolBuilder.outputSchema(JsonSchemaGenerator.generateFromClass(methodReturnType));
+						toolBuilder
+							.outputSchema(JsonSchemaGenerator.generateFromType(mcpToolMethod.getGenericReturnType()));
 					}
 
 					var tool = toolBuilder.build();

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProviderTests.java
@@ -22,17 +22,23 @@ import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpTool;
 
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.ToolAnnotations;
+import net.javacrumbs.jsonunit.core.Option;
 import reactor.core.publisher.Mono;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 
 /**
  * Tests for {@link SyncStatelessMcpToolProvider}.
@@ -579,24 +585,14 @@ public class SyncStatelessMcpToolProviderTests {
 	@Test
 	void testToolWithOutputSchemaGeneration() {
 		// Define a custom result class
-		class CustomResult {
-
-			public String message;
-
-			public int count;
-
-			public CustomResult(String message, int count) {
-				this.message = message;
-				this.count = count;
-			}
-
+		record CustomResult(String message, int count) {
 		}
 
 		class OutputSchemaTool {
 
-			@McpTool(name = "output-schema-tool", description = "Tool with output schema")
-			public CustomResult outputSchemaTool(String input) {
-				return new CustomResult("Processed: " + input, input.length());
+			@McpTool(name = "output-schema-tool", description = "Tool with output schema", generateOutputSchema = true)
+			public List<CustomResult> outputSchemaTool(String input) {
+				return List.of(new CustomResult("Processed: " + input, input.length()));
 			}
 
 		}
@@ -615,6 +611,9 @@ public class SyncStatelessMcpToolProviderTests {
 		String outputSchemaString = toolSpec.tool().outputSchema().toString();
 		assertThat(outputSchemaString).contains("message");
 		assertThat(outputSchemaString).contains("count");
+		assertThat(outputSchemaString).isEqualTo(
+				"{$schema=https://json-schema.org/draft/2020-12/schema, type=array, items={type=object, properties={count={type=integer, format=int32}, message={type=string}}}}");
+
 	}
 
 	@Test
@@ -650,6 +649,47 @@ public class SyncStatelessMcpToolProviderTests {
 		assertThat(toolSpec.tool().name()).isEqualTo("no-output-schema-tool");
 		// Output schema should not be generated when disabled
 		assertThat(toolSpec.tool().outputSchema()).isNull();
+	}
+
+	@Test
+	void testToolWithListReturnType() {
+
+		record CustomResult(String message) {
+		}
+
+		class ListResponseTool {
+
+			@McpTool(name = "list-response", description = "Tool List response")
+			public List<CustomResult> listResponseTool(String input) {
+				return List.of(new CustomResult("Processed: " + input));
+			}
+
+		}
+
+		ListResponseTool toolObject = new ListResponseTool();
+		SyncStatelessMcpToolProvider provider = new SyncStatelessMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		SyncToolSpecification toolSpec = toolSpecs.get(0);
+
+		assertThat(toolSpec.tool().name()).isEqualTo("list-response");
+		assertThat(toolSpec.tool().outputSchema()).isNull();
+
+		BiFunction<McpTransportContext, CallToolRequest, McpSchema.CallToolResult> callHandler = toolSpec.callHandler();
+
+		McpSchema.CallToolResult result = callHandler.apply(mock(McpTransportContext.class),
+				new CallToolRequest("list-response", Map.of("input", "test")));
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(McpSchema.TextContent.class);
+
+		String jsonText = ((TextContent) result.content().get(0)).text();
+		assertThatJson(jsonText).when(Option.IGNORING_ARRAY_ORDER).isArray().hasSize(1);
+		assertThatJson(jsonText).when(Option.IGNORING_ARRAY_ORDER).isEqualTo(json("""
+				[{"message":"Processed: test"}]"""));
 	}
 
 	@Test


### PR DESCRIPTION
- Change @McpTool generateOutputSchema default from true to false
- Add documentation for output schema generation behavior
- Enhance return type handling in tool method callbacks:
  * Improve void/Void type detection and handling
  * Return strings directly without JSON serialization in TEXT mode
  * Better null value handling with explicit null text content
  * Serialize complex objects to JSON for text content
- Add JsonSchemaGenerator.generateFromType() for better generic type support
- Update all tool providers to use type-based schema generation
- Add test coverage for:
  * List return types with complex objects
  * Output schema generation behavior
  * String vs complex object serialization
  * Flux/Mono reactive return types

BREAKING CHANGE: @McpTool generateOutputSchema now defaults to false, requiring explicit enablement for output schema generation