### PR TITLE
feat: upgrade to MCP Java SDK 0.13.0-SNAPSHOT and adapt to McpJsonMapper API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ and a Java MCP SDK dependency:
 <dependency>
     <groupId>io.modelcontextprotocol.sdk</groupId>
     <artifactId>mcp</artifactId>
-    <version>0.12.0</version>
+    <version>0.13.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -1999,7 +1999,7 @@ public class StatelessMcpServerFactory {
 
 - Java 17 or higher
 - Reactor Core (for async operations)
-- MCP Java SDK 0.12.0 or higher
+- MCP Java SDK 0.13.0-SNAPSHOT or higher
 
 ## Building from Source
 

--- a/mcp-annotations/pom.xml
+++ b/mcp-annotations/pom.xml
@@ -56,11 +56,11 @@
 			<version>${swagger-annotations.version}</version>
 		</dependency>
 
-		<dependency>
+		<!-- <dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson-databind.version}</version>
-		</dependency>
+		</dependency> -->
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AbstractMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AbstractMcpToolProvider.java
@@ -3,12 +3,15 @@ package org.springaicommunity.mcp.provider.tool;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.util.Assert;
 import org.springaicommunity.mcp.annotation.McpTool;
 
 public abstract class AbstractMcpToolProvider {
 
 	protected final List<Object> toolObjects;
+
+	protected McpJsonMapper jsonMapper = McpJsonMapper.createDefault();
 
 	public AbstractMcpToolProvider(List<Object> toolObjects) {
 		Assert.notNull(toolObjects, "toolObjects cannot be null");
@@ -25,6 +28,14 @@ public abstract class AbstractMcpToolProvider {
 
 	protected Class<? extends Throwable> doGetToolCallException() {
 		return Exception.class;
+	}
+
+	public void setJsonMapper(McpJsonMapper jsonMapper) {
+		this.jsonMapper = jsonMapper;
+	}
+
+	public McpJsonMapper getJsonMapper() {
+		return this.jsonMapper;
 	}
 
 }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncMcpToolProvider.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -79,7 +80,7 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 					var toolBuilder = McpSchema.Tool.builder()
 						.name(toolName)
 						.description(toolDescrption)
-						.inputSchema(inputSchema);
+						.inputSchema(this.getJsonMapper(), inputSchema);
 
 					var title = toolJavaAnnotation.title();
 
@@ -119,8 +120,8 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 									: null;
 							if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 									&& !ClassUtils.isSimpleValueType(methodReturnType)) {
-								toolBuilder
-									.outputSchema(JsonSchemaGenerator.generateFromClass((Class<?>) typeArgument));
+								toolBuilder.outputSchema(this.getJsonMapper(),
+										JsonSchemaGenerator.generateFromClass((Class<?>) typeArgument));
 							}
 						});
 					}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -21,6 +21,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
@@ -83,7 +84,7 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 					var toolBuilder = McpSchema.Tool.builder()
 						.name(toolName)
 						.description(toolDescrption)
-						.inputSchema(inputSchema);
+						.inputSchema(this.getJsonMapper(), inputSchema);
 
 					var title = toolJavaAnnotation.title();
 
@@ -123,7 +124,8 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 									: null;
 							if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 									&& !ClassUtils.isSimpleValueType(methodReturnType)) {
-								toolBuilder.outputSchema(JsonSchemaGenerator.generateFromType(typeArgument));
+								toolBuilder.outputSchema(this.getJsonMapper(),
+										JsonSchemaGenerator.generateFromType(typeArgument));
 							}
 						});
 					}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncMcpToolProvider.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -74,10 +75,10 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 
 					String inputSchema = JsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
-					var toolBuilder = McpSchema.Tool.builder()
+					McpSchema.Tool.Builder toolBuilder = McpSchema.Tool.builder()
 						.name(toolName)
 						.description(toolDescription)
-						.inputSchema(inputSchema);
+						.inputSchema(this.getJsonMapper(), inputSchema);
 
 					var title = toolJavaAnnotation.title();
 
@@ -104,8 +105,6 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 					}
 					toolBuilder.title(title);
 
-					// ReactiveUtils.isReactiveReturnTypeOfCallToolResult(mcpToolMethod);
-
 					// Generate Output Schema from the method return type.
 					// Output schema is not generated for primitive types, void,
 					// CallToolResult, simple value types (String, etc.)
@@ -116,8 +115,8 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 							&& methodReturnType != void.class && !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 							&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 
-						toolBuilder
-							.outputSchema(JsonSchemaGenerator.generateFromType(mcpToolMethod.getGenericReturnType()));
+						toolBuilder.outputSchema(this.getJsonMapper(),
+								JsonSchemaGenerator.generateFromType(mcpToolMethod.getGenericReturnType()));
 					}
 
 					var tool = toolBuilder.build();

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProvider.java
@@ -21,6 +21,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
@@ -80,7 +81,7 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 					var toolBuilder = McpSchema.Tool.builder()
 						.name(toolName)
 						.description(toolDescrption)
-						.inputSchema(inputSchema);
+						.inputSchema(this.getJsonMapper(), inputSchema);
 
 					var title = toolJavaAnnotation.title();
 
@@ -119,8 +120,8 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 							&& methodReturnType != void.class && !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
 							&& !ClassUtils.isSimpleValueType(methodReturnType)) {
 
-						toolBuilder
-							.outputSchema(JsonSchemaGenerator.generateFromType(mcpToolMethod.getGenericReturnType()));
+						toolBuilder.outputSchema(this.getJsonMapper(),
+								JsonSchemaGenerator.generateFromType(mcpToolMethod.getGenericReturnType()));
 					}
 
 					var tool = toolBuilder.build();

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/changed/tool/AsyncMcpToolListChangedMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/changed/tool/AsyncMcpToolListChangedMethodCallbackTests.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpToolListChanged;
-
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -26,8 +26,16 @@ import reactor.test.StepVerifier;
 public class AsyncMcpToolListChangedMethodCallbackTests {
 
 	private static final List<McpSchema.Tool> TEST_TOOLS = List.of(
-			McpSchema.Tool.builder().name("test-tool-1").description("Test Tool 1").inputSchema("{}").build(),
-			McpSchema.Tool.builder().name("test-tool-2").description("Test Tool 2").inputSchema("{}").build());
+			McpSchema.Tool.builder()
+				.name("test-tool-1")
+				.description("Test Tool 1")
+				.inputSchema(McpJsonMapper.createDefault(), "{}")
+				.build(),
+			McpSchema.Tool.builder()
+				.name("test-tool-2")
+				.description("Test Tool 2")
+				.inputSchema(McpJsonMapper.createDefault(), "{}")
+				.build());
 
 	/**
 	 * Test class with valid methods.

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/changed/tool/SyncMcpToolListChangedMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/changed/tool/SyncMcpToolListChangedMethodCallbackTests.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpToolListChanged;
-
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 /**
@@ -24,8 +24,16 @@ import io.modelcontextprotocol.spec.McpSchema;
 public class SyncMcpToolListChangedMethodCallbackTests {
 
 	private static final List<McpSchema.Tool> TEST_TOOLS = List.of(
-			McpSchema.Tool.builder().name("test-tool-1").description("Test Tool 1").inputSchema("{}").build(),
-			McpSchema.Tool.builder().name("test-tool-2").description("Test Tool 2").inputSchema("{}").build());
+			McpSchema.Tool.builder()
+				.name("test-tool-1")
+				.description("Test Tool 1")
+				.inputSchema(McpJsonMapper.createDefault(), "{}")
+				.build(),
+			McpSchema.Tool.builder()
+				.name("test-tool-2")
+				.description("Test Tool 2")
+				.inputSchema(McpJsonMapper.createDefault(), "{}")
+				.build());
 
 	/**
 	 * Test class with valid methods.

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/AsyncCallToolRequestSupportTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/AsyncCallToolRequestSupportTests.java
@@ -320,8 +320,8 @@ public class AsyncCallToolRequestSupportTests {
 			assertThat(result).isNotNull();
 			assertThat(result.isError()).isFalse();
 			assertThat(result.structuredContent()).isNotNull();
-			assertThat(result.structuredContent()).containsEntry("message", "test-message");
-			assertThat(result.structuredContent()).containsEntry("value", 42);
+			assertThat((Map<String, Object>) result.structuredContent()).containsEntry("message", "test-message");
+			assertThat((Map<String, Object>) result.structuredContent()).containsEntry("value", 42);
 		}).verifyComplete();
 	}
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/AsyncMcpToolMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/AsyncMcpToolMethodCallbackTests.java
@@ -570,8 +570,8 @@ public class AsyncMcpToolMethodCallbackTests {
 			assertThat(result.isError()).isFalse();
 			assertThat(result.content()).isEmpty();
 			assertThat(result.structuredContent()).isNotNull();
-			assertThat(result.structuredContent()).containsEntry("name", "test");
-			assertThat(result.structuredContent()).containsEntry("value", 42);
+			assertThat((Map<String, Object>) result.structuredContent()).containsEntry("name", "test");
+			assertThat((Map<String, Object>) result.structuredContent()).containsEntry("value", 42);
 		}).verifyComplete();
 	}
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/AsyncStatelessMcpToolMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/AsyncStatelessMcpToolMethodCallbackTests.java
@@ -606,8 +606,8 @@ public class AsyncStatelessMcpToolMethodCallbackTests {
 			assertThat(result.isError()).isFalse();
 			assertThat(result.content()).isEmpty();
 			assertThat(result.structuredContent()).isNotNull();
-			assertThat(result.structuredContent()).containsEntry("name", "test");
-			assertThat(result.structuredContent()).containsEntry("value", 42);
+			assertThat((Map<String, Object>) result.structuredContent()).containsEntry("name", "test");
+			assertThat((Map<String, Object>) result.structuredContent()).containsEntry("value", 42);
 		}).verifyComplete();
 	}
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/CallToolRequestSupportTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/CallToolRequestSupportTests.java
@@ -446,8 +446,8 @@ public class CallToolRequestSupportTests {
 		assertThat(result).isNotNull();
 		assertThat(result.isError()).isFalse();
 		assertThat(result.structuredContent()).isNotNull();
-		assertThat(result.structuredContent()).containsEntry("message", "test-message");
-		assertThat(result.structuredContent()).containsEntry("value", 42);
+		assertThat((Map<String, Object>) result.structuredContent()).containsEntry("message", "test-message");
+		assertThat((Map<String, Object>) result.structuredContent()).containsEntry("value", 42);
 	}
 
 	@Test

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/SyncMcpToolMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/SyncMcpToolMethodCallbackTests.java
@@ -518,8 +518,8 @@ public class SyncMcpToolMethodCallbackTests {
 		// the new implementation should return structured content
 		assertThat(result.content()).isEmpty();
 		assertThat(result.structuredContent()).isNotNull();
-		assertThat(result.structuredContent()).containsEntry("name", "test");
-		assertThat(result.structuredContent()).containsEntry("value", 42);
+		assertThat((Map<String, Object>) result.structuredContent()).containsEntry("name", "test");
+		assertThat((Map<String, Object>) result.structuredContent()).containsEntry("value", 42);
 	}
 
 	@Test

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/SyncStatelessMcpToolMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/SyncStatelessMcpToolMethodCallbackTests.java
@@ -539,8 +539,8 @@ public class SyncStatelessMcpToolMethodCallbackTests {
 		// the new implementation should return structured content
 		assertThat(result.content()).isEmpty();
 		assertThat(result.structuredContent()).isNotNull();
-		assertThat(result.structuredContent()).containsEntry("name", "test");
-		assertThat(result.structuredContent()).containsEntry("value", 42);
+		assertThat((Map<String, Object>) result.structuredContent()).containsEntry("name", "test");
+		assertThat((Map<String, Object>) result.structuredContent()).containsEntry("value", 42);
 	}
 
 	@Test

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/changed/tool/AsyncMcpToolListChangedProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/changed/tool/AsyncMcpToolListChangedProviderTests.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpToolListChanged;
 import org.springaicommunity.mcp.method.changed.tool.AsyncToolListChangedSpecification;
-
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -26,8 +26,16 @@ import reactor.test.StepVerifier;
 public class AsyncMcpToolListChangedProviderTests {
 
 	private static final List<McpSchema.Tool> TEST_TOOLS = List.of(
-			McpSchema.Tool.builder().name("test-tool-1").description("Test Tool 1").inputSchema("{}").build(),
-			McpSchema.Tool.builder().name("test-tool-2").description("Test Tool 2").inputSchema("{}").build());
+			McpSchema.Tool.builder()
+				.name("test-tool-1")
+				.description("Test Tool 1")
+				.inputSchema(McpJsonMapper.createDefault(), "{}")
+				.build(),
+			McpSchema.Tool.builder()
+				.name("test-tool-2")
+				.description("Test Tool 2")
+				.inputSchema(McpJsonMapper.createDefault(), "{}")
+				.build());
 
 	/**
 	 * Test class with tool list changed consumer methods.

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/changed/tool/SyncMcpToolListChangedProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/changed/tool/SyncMcpToolListChangedProviderTests.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpToolListChanged;
 import org.springaicommunity.mcp.method.changed.tool.SyncToolListChangedSpecification;
-
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 /**
@@ -24,8 +24,16 @@ import io.modelcontextprotocol.spec.McpSchema;
 public class SyncMcpToolListChangedProviderTests {
 
 	private static final List<McpSchema.Tool> TEST_TOOLS = List.of(
-			McpSchema.Tool.builder().name("test-tool-1").description("Test Tool 1").inputSchema("{}").build(),
-			McpSchema.Tool.builder().name("test-tool-2").description("Test Tool 2").inputSchema("{}").build());
+			McpSchema.Tool.builder()
+				.name("test-tool-1")
+				.description("Test Tool 1")
+				.inputSchema(McpJsonMapper.createDefault(), "{}")
+				.build(),
+			McpSchema.Tool.builder()
+				.name("test-tool-2")
+				.description("Test Tool 2")
+				.inputSchema(McpJsonMapper.createDefault(), "{}")
+				.build());
 
 	/**
 	 * Test class with tool list changed consumer methods.

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,13 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 
-		<mcp.java.sdk.version>0.12.1</mcp.java.sdk.version>
+		<mcp.java.sdk.version>0.13.0-SNAPSHOT</mcp.java.sdk.version>
 
 		<jsonschema.version>4.38.0</jsonschema.version>
 		<swagger-annotations.version>2.2.36</swagger-annotations.version>
-		<jackson-databind.version>2.19.2</jackson-databind.version>
+		
+		<!-- MUST KEEP JACKSON VERSION ALIGNED WITH the mcp-json-jackson2 version -->
+		<jackson-databind.version>2.17.0</jackson-databind.version>
 
 		<slf4j-api.version>2.0.16</slf4j-api.version>
 		<logback.version>1.5.15</logback.version>


### PR DESCRIPTION
- Upgrade mcp.java.sdk.version from 0.12.1 to 0.13.0-SNAPSHOT
- Add McpJsonMapper support to AbstractMcpToolProvider with getter/setter methods
- Update all tool providers to use McpJsonMapper for inputSchema and outputSchema
- Comment out jackson-databind dependency in mcp-annotations module
- Downgrade jackson-databind version to 2.17.0 for compatibility
- Update test files to use McpJsonMapper.createDefault() for tool building
- Add explicit casting in test assertions to resolve type safety warnings

This change adapts the codebase to work with the new MCP SDK API that requires McpJsonMapper for JSON schema handling instead of raw string schemas.