### PR TITLE
feat: support list return types in structured MCP tool content

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -251,7 +251,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T> {
 
 		if (this.returnMode == ReturnMode.STRUCTURED) {
 			String jsonOutput = JsonParser.toJson(value);
-			Map<String, Object> structuredOutput = JsonParser.fromJson(jsonOutput, MAP_TYPE_REFERENCE);
+			Object structuredOutput = JsonParser.fromJson(jsonOutput, MAP_TYPE_REFERENCE);
 			return CallToolResult.builder().structuredContent(structuredOutput).build();
 		}
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractSyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractSyncMcpToolMethodCallback.java
@@ -162,7 +162,7 @@ public abstract class AbstractSyncMcpToolMethodCallback<T> {
 
 		if (this.returnMode == ReturnMode.STRUCTURED) {
 			String jsonOutput = JsonParser.toJson(result);
-			Map<String, Object> structuredOutput = JsonParser.fromJson(jsonOutput, MAP_TYPE_REFERENCE);
+			Object structuredOutput = JsonParser.fromJson(jsonOutput, Object.class);
 			return CallToolResult.builder().structuredContent(structuredOutput).build();
 		}
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/SyncMcpToolMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/tool/SyncMcpToolMethodCallbackTests.java
@@ -483,7 +483,7 @@ public class SyncMcpToolMethodCallbackTests {
 	}
 
 	@Test
-	public void testToolWithStructuredOutput() throws Exception {
+	public void testToolWithTextOutput() throws Exception {
 		TestToolProvider provider = new TestToolProvider();
 		Method method = TestToolProvider.class.getMethod("processObject", TestObject.class);
 		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
@@ -544,6 +544,28 @@ public class SyncMcpToolMethodCallbackTests {
 		assertThatJson(jsonText).when(Option.IGNORING_ARRAY_ORDER).isArray().hasSize(1);
 		assertThatJson(jsonText).when(Option.IGNORING_ARRAY_ORDER).isEqualTo(json("""
 				[{"name":"test","value":42}]"""));
+	}
+
+	@Test
+	public void testToolReturningStructuredComplexListObject() throws Exception {
+		TestToolProvider provider = new TestToolProvider();
+		Method method = TestToolProvider.class.getMethod("returnListObjectTool", String.class, int.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.STRUCTURED, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("return-list-object-tool", Map.of("name", "test", "value", 42));
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+
+		assertThat(result.structuredContent()).isNotNull();
+		assertThat(result.structuredContent()).isInstanceOf(List.class);
+		assertThat((List<?>) result.structuredContent()).hasSize(1);
+		Map<String, Object> firstEntry = ((List<Map<String, Object>>) result.structuredContent()).get(0);
+		assertThat(firstEntry).containsEntry("name", "test");
+		assertThat(firstEntry).containsEntry("value", 42);
 	}
 
 	@Test

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProviderTests.java
@@ -693,6 +693,46 @@ public class SyncStatelessMcpToolProviderTests {
 	}
 
 	@Test
+	void testToolWithStructuredListReturnType() {
+
+		record CustomResult(String message) {
+		}
+
+		class ListResponseTool {
+
+			@McpTool(name = "list-response", description = "Tool List response", generateOutputSchema = true)
+			public List<CustomResult> listResponseTool(String input) {
+				return List.of(new CustomResult("Processed: " + input));
+			}
+
+		}
+
+		ListResponseTool toolObject = new ListResponseTool();
+		SyncStatelessMcpToolProvider provider = new SyncStatelessMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		SyncToolSpecification toolSpec = toolSpecs.get(0);
+
+		assertThat(toolSpec.tool().name()).isEqualTo("list-response");
+		assertThat(toolSpec.tool().outputSchema()).isNotNull();
+
+		BiFunction<McpTransportContext, CallToolRequest, McpSchema.CallToolResult> callHandler = toolSpec.callHandler();
+
+		McpSchema.CallToolResult result = callHandler.apply(mock(McpTransportContext.class),
+				new CallToolRequest("list-response", Map.of("input", "test")));
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+
+		assertThat(result.structuredContent()).isInstanceOf(List.class);
+		assertThat((List<?>) result.structuredContent()).hasSize(1);
+		Map<String, Object> firstEntry = ((List<Map<String, Object>>) result.structuredContent()).get(0);
+		assertThat(firstEntry).containsEntry("message", "Processed: test");
+	}
+
+	@Test
 	void testToolWithPrimitiveReturnTypeNoOutputSchema() {
 		class PrimitiveTool {
 


### PR DESCRIPTION
- Change structuredOutput type from Map<String, Object> to Object to support lists
- Add comprehensive test coverage for tools returning List<ComplexObject>
- Update both sync and async tool method callbacks
- Rename misleading test method name for clarity

This enables MCP tools to return structured lists of complex objects, not just map-based structures, improving flexibility for tool responses.