### PR TITLE
feat: enhance McpResource annotation with title and annotations support

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/ResourceAdapter.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/ResourceAdapter.java
@@ -3,6 +3,8 @@
 */
 package org.springaicommunity.mcp.adapter;
 
+import java.util.List;
+
 import io.modelcontextprotocol.spec.McpSchema;
 import org.springaicommunity.mcp.annotation.McpResource;
 
@@ -14,17 +16,31 @@ public class ResourceAdapter {
 	private ResourceAdapter() {
 	}
 
-	public static McpSchema.Resource asResource(McpResource mcpResource) {
-		String name = mcpResource.name();
+	public static McpSchema.Resource asResource(McpResource mcpResourceAnnotation) {
+		String name = mcpResourceAnnotation.name();
 		if (name == null || name.isEmpty()) {
 			name = "resource"; // Default name when not specified
 		}
-		return McpSchema.Resource.builder()
-			.uri(mcpResource.uri())
+
+		var resourceBuilder = McpSchema.Resource.builder()
+			.uri(mcpResourceAnnotation.uri())
 			.name(name)
-			.description(mcpResource.description())
-			.mimeType(mcpResource.mimeType())
-			.build();
+			.title(mcpResourceAnnotation.title())
+			.description(mcpResourceAnnotation.description())
+			.mimeType(mcpResourceAnnotation.mimeType());
+
+		// Only set annotations if not default value is provided
+		// This is a workaround since Java annotations do not support null default values
+		// and we want to avoid setting empty annotations.
+		// The default annotations value is ignored.
+		// The user must explicitly set the annotations to get them included.
+		var annotations = mcpResourceAnnotation.annotations();
+		if (annotations != null && annotations.lastModified() != null && !annotations.lastModified().isEmpty()) {
+			resourceBuilder
+				.annotations(new McpSchema.Annotations(List.of(annotations.audience()), annotations.priority()));
+		}
+
+		return resourceBuilder.build();
 	}
 
 	public static McpSchema.ResourceTemplate asResourceTemplate(McpResource mcpResource) {

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpResource.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpResource.java
@@ -10,6 +10,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.modelcontextprotocol.spec.McpSchema.Role;
+
 /**
  * Marks a method as a MCP Resource.
  *
@@ -21,10 +23,15 @@ import java.lang.annotation.Target;
 public @interface McpResource {
 
 	/**
-	 * A human-readable name for this resource. This can be used by clients to populate UI
-	 * elements.
+	 * Intended for programmatic or logical use, but used as a display name in past specs
+	 * or fallback (if title isn’t present).
 	 */
 	String name() default "";
+
+	/**
+	 * Optional human-readable name of the prompt for display purposes.
+	 */
+	String title() default "";
 
 	/**
 	 * the URI of the resource.
@@ -42,5 +49,38 @@ public @interface McpResource {
 	 * The MIME type of this resource, if known.
 	 */
 	String mimeType() default "text/plain";
+
+	/**
+	 * Optional annotations for the client. Note: The default annotations value is
+	 * ignored.
+	 */
+	McpAnnotations annotations() default @McpAnnotations(audience = { Role.USER }, lastModified = "", priority = 0.5);
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.ANNOTATION_TYPE)
+	public @interface McpAnnotations {
+
+		/**
+		 * Describes who the intended customer of this object or data is. It can include
+		 * multiple entries to indicate content useful for multiple audiences (e.g.,
+		 * [“user”, “assistant”]).
+		 */
+		Role[] audience();
+
+		/**
+		 * The date and time (in ISO 8601 format) when the resource was last modified.
+		 */
+		String lastModified() default "";
+
+		/**
+		 * Describes how important this data is for operating the server.
+		 *
+		 * A value of 1 means “most important,” and indicates that the data is effectively
+		 * required, while 0 means “least important,” and indicates that the data is
+		 * entirely optional.
+		 */
+		double priority();
+
+	}
 
 }

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/AsyncMcpResourceMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/AsyncMcpResourceMethodCallbackTests.java
@@ -14,6 +14,7 @@ import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
+import io.modelcontextprotocol.spec.McpSchema.Role;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import io.modelcontextprotocol.util.McpUriTemplateManager;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
@@ -253,6 +254,11 @@ public class AsyncMcpResourceMethodCallbackTests {
 			}
 
 			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
 			public String description() {
 				return "";
 			}
@@ -262,6 +268,30 @@ public class AsyncMcpResourceMethodCallbackTests {
 				return "text/plain";
 			}
 
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public Role[] audience() {
+						return new Role[] { Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
+			}
 		};
 	}
 
@@ -563,6 +593,11 @@ public class AsyncMcpResourceMethodCallbackTests {
 			}
 
 			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
 			public String description() {
 				return "";
 			}
@@ -572,6 +607,30 @@ public class AsyncMcpResourceMethodCallbackTests {
 				return "";
 			}
 
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public Role[] audience() {
+						return new Role[] { Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
+			}
 		};
 
 		assertThatThrownBy(() -> AsyncMcpResourceMethodCallback.builder()

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/AsyncStatelessMcpResourceMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/AsyncStatelessMcpResourceMethodCallbackTests.java
@@ -14,6 +14,7 @@ import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
+import io.modelcontextprotocol.spec.McpSchema.Role;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import io.modelcontextprotocol.util.McpUriTemplateManager;
 import io.modelcontextprotocol.util.McpUriTemplateManagerFactory;
@@ -208,6 +209,11 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			}
 
 			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
 			public String description() {
 				return "";
 			}
@@ -217,6 +223,30 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 				return "text/plain";
 			}
 
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public Role[] audience() {
+						return new Role[] { Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
+			}
 		};
 	}
 
@@ -524,6 +554,11 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 			}
 
 			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
 			public String description() {
 				return "";
 			}
@@ -533,6 +568,30 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 				return "";
 			}
 
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public Role[] audience() {
+						return new Role[] { Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
+			}
 		};
 
 		assertThatThrownBy(() -> AsyncStatelessMcpResourceMethodCallback.builder()

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/McpResourceUriValidationTest.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/McpResourceUriValidationTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
+import io.modelcontextprotocol.spec.McpSchema.Role;
 import org.springaicommunity.mcp.adapter.ResourceAdapter;
 import org.springaicommunity.mcp.annotation.McpResource;
 
@@ -51,6 +52,11 @@ public class McpResourceUriValidationTest {
 			}
 
 			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
 			public String description() {
 				return "";
 			}
@@ -58,6 +64,31 @@ public class McpResourceUriValidationTest {
 			@Override
 			public String mimeType() {
 				return "";
+			}
+
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public Role[] audience() {
+						return new Role[] { Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
 			}
 		};
 	}
@@ -81,6 +112,11 @@ public class McpResourceUriValidationTest {
 			}
 
 			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
 			public String description() {
 				return "";
 			}
@@ -90,6 +126,30 @@ public class McpResourceUriValidationTest {
 				return "";
 			}
 
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public Role[] audience() {
+						return new Role[] { Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
+			}
 		};
 	}
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/SyncMcpResourceMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/SyncMcpResourceMethodCallbackTests.java
@@ -13,6 +13,7 @@ import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
+import io.modelcontextprotocol.spec.McpSchema.Role;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.adapter.ResourceAdapter;
@@ -224,6 +225,11 @@ public class SyncMcpResourceMethodCallbackTests {
 			}
 
 			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
 			public String description() {
 				return "Test resource description";
 			}
@@ -231,6 +237,31 @@ public class SyncMcpResourceMethodCallbackTests {
 			@Override
 			public String mimeType() {
 				return "text/plain";
+			}
+
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public Role[] audience() {
+						return new Role[] { Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
 			}
 		};
 	}
@@ -494,6 +525,11 @@ public class SyncMcpResourceMethodCallbackTests {
 			}
 
 			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
 			public String description() {
 				return "Test resource with extra URI variables";
 			}
@@ -501,6 +537,31 @@ public class SyncMcpResourceMethodCallbackTests {
 			@Override
 			public String mimeType() {
 				return "text/plain";
+			}
+
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public Role[] audience() {
+						return new Role[] { Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
 			}
 		};
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/SyncStatelessMcpResourceMethodCallbackTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/method/resource/SyncStatelessMcpResourceMethodCallbackTests.java
@@ -14,6 +14,7 @@ import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
+import io.modelcontextprotocol.spec.McpSchema.Role;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.adapter.ResourceAdapter;
@@ -190,6 +191,11 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			}
 
 			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
 			public String description() {
 				return "Test resource description";
 			}
@@ -197,6 +203,31 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			@Override
 			public String mimeType() {
 				return "text/plain";
+			}
+
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public Role[] audience() {
+						return new Role[] { Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
 			}
 		};
 	}
@@ -572,6 +603,11 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			}
 
 			@Override
+			public String title() {
+				return "";
+			}
+
+			@Override
 			public String description() {
 				return "Test resource with extra URI variables";
 			}
@@ -579,6 +615,31 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 			@Override
 			public String mimeType() {
 				return "text/plain";
+			}
+
+			@Override
+			public McpAnnotations annotations() {
+				return new McpAnnotations() {
+					@Override
+					public Class<? extends java.lang.annotation.Annotation> annotationType() {
+						return McpAnnotations.class;
+					}
+
+					@Override
+					public Role[] audience() {
+						return new Role[] { Role.USER };
+					}
+
+					@Override
+					public String lastModified() {
+						return "";
+					}
+
+					@Override
+					public double priority() {
+						return 0.5;
+					}
+				};
 			}
 		};
 


### PR DESCRIPTION
- Add title field to McpResource annotation for display purposes
- Add annotations support with audience, lastModified, and priority fields
- Update ResourceAdapter to handle new title and conditional annotations
- Rename parameter in ResourceAdapter for better clarity
- Update related tests
- Add nested McpAnnotations annotation with Role-based audience support