### PR TITLE
refactor: enhance MCP method callbacks with improved type safety and …

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/ErrorUtils.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/ErrorUtils.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp;
+
+import java.util.Objects;
+
+public class ErrorUtils {
+
+	public static Throwable findCauseUsingPlainJava(Throwable throwable) {
+		Objects.requireNonNull(throwable);
+		Throwable rootCause = throwable;
+		while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+			rootCause = rootCause.getCause();
+		}
+		return rootCause;
+	}
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/prompt/AsyncStatelessMcpPromptMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/prompt/AsyncStatelessMcpPromptMethodCallback.java
@@ -8,8 +8,13 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import org.springaicommunity.mcp.ErrorUtils;
 import org.springaicommunity.mcp.annotation.McpPrompt;
 import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.spec.McpSchema.PromptMessage;
@@ -30,6 +35,42 @@ public final class AsyncStatelessMcpPromptMethodCallback extends AbstractMcpProm
 
 	private AsyncStatelessMcpPromptMethodCallback(Builder builder) {
 		super(builder.method, builder.bean, builder.prompt);
+	}
+
+	@Override
+	protected void validateParamType(Class<?> paramType) {
+
+		if (McpSyncServerExchange.class.isAssignableFrom(paramType)
+				|| McpAsyncServerExchange.class.isAssignableFrom(paramType)) {
+
+			throw new IllegalArgumentException(
+					"Stateless Streamable-Http prompt method must not declare parameter of type: " + paramType.getName()
+							+ ". Use McpTransportContext instead." + " Method: " + this.method.getName() + " in "
+							+ this.method.getDeclaringClass().getName());
+		}
+	}
+
+	@Override
+	protected Object assignExchangeType(Class<?> paramType, Object exchange) {
+
+		if (McpTransportContext.class.isAssignableFrom(paramType)) {
+			if (exchange instanceof McpTransportContext transportContext) {
+				return transportContext;
+			}
+			else if (exchange instanceof McpSyncServerExchange syncServerExchange) {
+				throw new IllegalArgumentException("Unsupported Sync exchange type: "
+						+ syncServerExchange.getClass().getName() + " for Sync method: " + method.getName() + " in "
+						+ method.getDeclaringClass().getName());
+
+			}
+			else if (exchange instanceof McpAsyncServerExchange asyncServerExchange) {
+				return asyncServerExchange.transportContext();
+			}
+		}
+
+		throw new IllegalArgumentException(
+				"Unsupported exchange type: " + (exchange != null ? exchange.getClass().getName() : "null")
+						+ " for method: " + method.getName() + " in " + method.getDeclaringClass().getName());
 	}
 
 	/**
@@ -70,14 +111,23 @@ public final class AsyncStatelessMcpPromptMethodCallback extends AbstractMcpProm
 				}
 			}
 			catch (Exception e) {
-				return Mono
-					.error(new McpPromptMethodException("Error invoking prompt method: " + this.method.getName(), e));
+
+				if (e instanceof McpError mcpError && mcpError.getJsonRpcError() != null) {
+					return Mono.error(mcpError);
+				}
+
+				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+					.message("Error invoking prompt method: " + this.method.getName() + " in "
+							+ this.bean.getClass().getName() + ". /nCause: "
+							+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())
+					.data(ErrorUtils.findCauseUsingPlainJava(e).getMessage())
+					.build());
 			}
 		});
 	}
 
 	@Override
-	protected boolean isExchangeOrContextType(Class<?> paramType) {
+	protected boolean isSupportedExchangeOrContextType(Class<?> paramType) {
 		return McpTransportContext.class.isAssignableFrom(paramType);
 	}
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/resource/AsyncMcpResourceMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/resource/AsyncMcpResourceMethodCallback.java
@@ -8,9 +8,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+import org.springaicommunity.mcp.ErrorUtils;
 import org.springaicommunity.mcp.annotation.McpResource;
-
+import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
@@ -34,6 +38,48 @@ public final class AsyncMcpResourceMethodCallback extends AbstractMcpResourceMet
 		super(builder.method, builder.bean, builder.uri, builder.name, builder.description, builder.mimeType,
 				builder.resultConverter, builder.uriTemplateManagerFactory, builder.contentType);
 		this.validateMethod(this.method);
+	}
+
+	@Override
+	protected void validateParamType(Class<?> paramType) {
+
+		if (McpSyncServerExchange.class.isAssignableFrom(paramType)) {
+			throw new IllegalArgumentException("Async prompt method must not declare parameter of type: "
+					+ paramType.getName() + ". Use McpAsyncServerExchange instead." + " Method: "
+					+ this.method.getName() + " in " + this.method.getDeclaringClass().getName());
+		}
+	}
+
+	@Override
+	protected Object assignExchangeType(Class<?> paramType, Object exchange) {
+
+		if (McpTransportContext.class.isAssignableFrom(paramType)) {
+			if (exchange instanceof McpTransportContext transportContext) {
+				return transportContext;
+			}
+			else if (exchange instanceof McpSyncServerExchange syncServerExchange) {
+				throw new IllegalArgumentException("Unsupported Async exchange type: "
+						+ syncServerExchange.getClass().getName() + " for Async method: " + method.getName() + " in "
+						+ method.getDeclaringClass().getName());
+
+			}
+			else if (exchange instanceof McpAsyncServerExchange asyncServerExchange) {
+				return asyncServerExchange.transportContext();
+			}
+		}
+		else if (McpAsyncServerExchange.class.isAssignableFrom(paramType)) {
+			if (exchange instanceof McpAsyncServerExchange asyncServerExchange) {
+				return asyncServerExchange;
+			}
+
+			throw new IllegalArgumentException(
+					"Unsupported exchange type: " + (exchange != null ? exchange.getClass().getName() : "null")
+							+ " for Async method: " + method.getName() + " in " + method.getDeclaringClass().getName());
+		}
+
+		throw new IllegalArgumentException(
+				"Unsupported exchange type: " + (exchange != null ? exchange.getClass().getName() : "null")
+						+ " for method: " + method.getName() + " in " + method.getDeclaringClass().getName());
 	}
 
 	/**
@@ -90,8 +136,16 @@ public final class AsyncMcpResourceMethodCallback extends AbstractMcpResourceMet
 				}
 			}
 			catch (Exception e) {
-				return Mono.error(
-						new McpResourceMethodException("Error invoking resource method: " + this.method.getName(), e));
+				if (e instanceof McpError mcpError && mcpError.getJsonRpcError() != null) {
+					return Mono.error(mcpError);
+				}
+
+				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+					.message("Error invoking resource method: " + this.method.getName() + " in "
+							+ this.bean.getClass().getName() + ". /nCause: "
+							+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())
+					.data(ErrorUtils.findCauseUsingPlainJava(e).getMessage())
+					.build());
 			}
 		});
 	}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/resource/SyncMcpResourceMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/resource/SyncMcpResourceMethodCallback.java
@@ -9,9 +9,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+import org.springaicommunity.mcp.ErrorUtils;
 import org.springaicommunity.mcp.annotation.McpResource;
-
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
@@ -32,6 +36,47 @@ public final class SyncMcpResourceMethodCallback extends AbstractMcpResourceMeth
 		super(builder.method, builder.bean, builder.uri, builder.name, builder.description, builder.mimeType,
 				builder.resultConverter, builder.uriTemplateManagerFactory, builder.contentType);
 		this.validateMethod(this.method);
+	}
+
+	@Override
+	protected void validateParamType(Class<?> paramType) {
+
+		if (McpAsyncServerExchange.class.isAssignableFrom(paramType)) {
+			throw new IllegalArgumentException("Sync prompt method must not declare parameter of type: "
+					+ paramType.getName() + ". Use McpSyncServerExchange instead." + " Method: " + this.method.getName()
+					+ " in " + this.method.getDeclaringClass().getName());
+		}
+	}
+
+	@Override
+	protected Object assignExchangeType(Class<?> paramType, Object exchange) {
+
+		if (McpTransportContext.class.isAssignableFrom(paramType)) {
+			if (exchange instanceof McpTransportContext transportContext) {
+				return transportContext;
+			}
+			else if (exchange instanceof McpSyncServerExchange syncServerExchange) {
+				return syncServerExchange.transportContext();
+			}
+			else if (exchange instanceof McpAsyncServerExchange asyncServerExchange) {
+				throw new IllegalArgumentException("Unsupported Async exchange type: "
+						+ asyncServerExchange.getClass().getName() + " for Sync method: " + method.getName() + " in "
+						+ method.getDeclaringClass().getName());
+			}
+		}
+		else if (McpSyncServerExchange.class.isAssignableFrom(paramType)) {
+			if (exchange instanceof McpSyncServerExchange syncServerExchange) {
+				return syncServerExchange;
+			}
+
+			throw new IllegalArgumentException(
+					"Unsupported exchange type: " + (exchange != null ? exchange.getClass().getName() : "null")
+							+ " for Sync method: " + method.getName() + " in " + method.getDeclaringClass().getName());
+		}
+
+		throw new IllegalArgumentException(
+				"Unsupported exchange type: " + (exchange != null ? exchange.getClass().getName() : "null")
+						+ " for method: " + method.getName() + " in " + method.getDeclaringClass().getName());
 	}
 
 	/**
@@ -77,7 +122,16 @@ public final class SyncMcpResourceMethodCallback extends AbstractMcpResourceMeth
 					this.contentType);
 		}
 		catch (Exception e) {
-			throw new McpResourceMethodException("Access error invoking resource method: " + this.method.getName(), e);
+			if (e instanceof McpError mcpError && mcpError.getJsonRpcError() != null) {
+				throw mcpError;
+			}
+
+			throw McpError.builder(ErrorCodes.INVALID_PARAMS)
+				.message("Error invoking resource method: " + this.method.getName() + " in "
+						+ this.bean.getClass().getName() + ". /nCause: "
+						+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())
+				.data(ErrorUtils.findCauseUsingPlainJava(e).getMessage())
+				.build();
 		}
 	}
 


### PR DESCRIPTION
…error handling

Those changes affect the Prompt and Resources Method callback implementations only

- Add abstract methods `validateParamType` and `assignExchangeType` for better parameter handling
- Implement strict type validation for exchange parameters (Sync vs Async vs Transport Context)
- Replace custom exceptions (`McpPromptMethodException`, `McpResourceMethodException`) with standardized `McpError`
- Add comprehensive parameter type validation with detailed error messages
- Enhance exchange type assignment logic with proper type checking
- Update all concrete implementations (Sync, Async, Stateless variants) for both prompt and resource callbacks
- Add test coverage for new validation logic and error scenarios