### PR TITLE
WIP feat: add support for MCP resource templates

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/McpProviderUtils.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/McpProviderUtils.java
@@ -18,12 +18,19 @@ package org.springaicommunity.mcp.provider;
 
 import java.lang.reflect.Method;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public class ProvidrerUtils {
+public class McpProviderUtils {
+
+	private static final Pattern URI_VARIABLE_PATTERN = Pattern.compile("\\{([^/]+?)\\}");
+
+	public static boolean isUriTemplate(String uri) {
+		return URI_VARIABLE_PATTERN.matcher(uri).find();
+	}
 
 	public final static Predicate<Method> isReactiveReturnType = method -> Mono.class
 		.isAssignableFrom(method.getReturnType()) || Flux.class.isAssignableFrom(method.getReturnType())

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncMcpResourceProvider.java
@@ -18,21 +18,23 @@ package org.springaicommunity.mcp.provider.resource;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceTemplateSpecification;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
+import io.modelcontextprotocol.util.Assert;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.method.resource.AsyncMcpResourceMethodCallback;
-
-import io.modelcontextprotocol.server.McpAsyncServerExchange;
-import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
-import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
-import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
-import io.modelcontextprotocol.util.Assert;
+import org.springaicommunity.mcp.provider.McpProviderUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -79,6 +81,11 @@ public class AsyncMcpResourceProvider {
 					var resourceAnnotation = doGetMcpResourceAnnotation(mcpResourceMethod);
 
 					var uri = resourceAnnotation.uri();
+
+					if (McpProviderUtils.isUriTemplate(uri)) {
+						return null;
+					}
+
 					var name = getName(mcpResourceMethod, resourceAnnotation);
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
@@ -101,6 +108,60 @@ public class AsyncMcpResourceProvider {
 
 					return resourceSpec;
 				})
+				.filter(Objects::nonNull)
+				.toList())
+			.flatMap(List::stream)
+			.toList();
+
+		if (resourceSpecs.isEmpty()) {
+			logger.warn("No resource methods found in the provided resource objects: {}", this.resourceObjects);
+		}
+
+		return resourceSpecs;
+	}
+
+	public List<AsyncResourceTemplateSpecification> getResourceTemplateSpecifications() {
+
+		List<AsyncResourceTemplateSpecification> resourceSpecs = this.resourceObjects.stream()
+			.map(resourceObject -> Stream.of(doGetClassMethods(resourceObject))
+				.filter(method -> method.isAnnotationPresent(McpResource.class))
+				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
+						|| Flux.class.isAssignableFrom(method.getReturnType())
+						|| Publisher.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
+				.map(mcpResourceMethod -> {
+
+					var resourceAnnotation = doGetMcpResourceAnnotation(mcpResourceMethod);
+
+					var uri = resourceAnnotation.uri();
+
+					if (!McpProviderUtils.isUriTemplate(uri)) {
+						return null;
+					}
+
+					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var description = resourceAnnotation.description();
+					var mimeType = resourceAnnotation.mimeType();
+
+					var mcpResourceTemplate = McpSchema.ResourceTemplate.builder()
+						.uri(uri)
+						.name(name)
+						.description(description)
+						.mimeType(mimeType)
+						.build();
+
+					BiFunction<McpAsyncServerExchange, ReadResourceRequest, Mono<ReadResourceResult>> methodCallback = AsyncMcpResourceMethodCallback
+						.builder()
+						.method(mcpResourceMethod)
+						.bean(resourceObject)
+						.resource(mcpResourceTemplate)
+						.build();
+
+					var resourceSpec = new AsyncResourceTemplateSpecification(mcpResourceTemplate, methodCallback);
+
+					return resourceSpec;
+				})
+				.filter(Objects::nonNull)
 				.toList())
 			.flatMap(List::stream)
 			.toList();

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProvider.java
@@ -18,6 +18,7 @@ package org.springaicommunity.mcp.provider.resource;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
@@ -26,8 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.method.resource.AsyncStatelessMcpResourceMethodCallback;
-
+import org.springaicommunity.mcp.provider.McpProviderUtils;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncResourceTemplateSpecification;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
@@ -79,6 +81,11 @@ public class AsyncStatelessMcpResourceProvider {
 					var resourceAnnotation = doGetMcpResourceAnnotation(mcpResourceMethod);
 
 					var uri = resourceAnnotation.uri();
+
+					if (McpProviderUtils.isUriTemplate(uri)) {
+						return null;
+					}
+
 					var name = getName(mcpResourceMethod, resourceAnnotation);
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
@@ -101,6 +108,60 @@ public class AsyncStatelessMcpResourceProvider {
 
 					return resourceSpec;
 				})
+				.filter(Objects::nonNull)
+				.toList())
+			.flatMap(List::stream)
+			.toList();
+
+		if (resourceSpecs.isEmpty()) {
+			logger.warn("No resource methods found in the provided resource objects: {}", this.resourceObjects);
+		}
+
+		return resourceSpecs;
+	}
+
+	public List<AsyncResourceTemplateSpecification> getResourceTemplateSpecifications() {
+
+		List<AsyncResourceTemplateSpecification> resourceSpecs = this.resourceObjects.stream()
+			.map(resourceObject -> Stream.of(doGetClassMethods(resourceObject))
+				.filter(method -> method.isAnnotationPresent(McpResource.class))
+				.filter(method -> Mono.class.isAssignableFrom(method.getReturnType())
+						|| Flux.class.isAssignableFrom(method.getReturnType())
+						|| Publisher.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
+				.map(mcpResourceMethod -> {
+
+					var resourceAnnotation = doGetMcpResourceAnnotation(mcpResourceMethod);
+
+					var uri = resourceAnnotation.uri();
+
+					if (!McpProviderUtils.isUriTemplate(uri)) {
+						return null;
+					}
+
+					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var description = resourceAnnotation.description();
+					var mimeType = resourceAnnotation.mimeType();
+
+					var mcpResource = McpSchema.ResourceTemplate.builder()
+						.uri(uri)
+						.name(name)
+						.description(description)
+						.mimeType(mimeType)
+						.build();
+
+					BiFunction<McpTransportContext, ReadResourceRequest, Mono<ReadResourceResult>> methodCallback = AsyncStatelessMcpResourceMethodCallback
+						.builder()
+						.method(mcpResourceMethod)
+						.bean(resourceObject)
+						.resource(mcpResource)
+						.build();
+
+					var resourceSpec = new AsyncResourceTemplateSpecification(mcpResource, methodCallback);
+
+					return resourceSpec;
+				})
+				.filter(Objects::nonNull)
 				.toList())
 			.flatMap(List::stream)
 			.toList();

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncMcpResourceProvider.java
@@ -18,12 +18,14 @@ package org.springaicommunity.mcp.provider.resource;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.method.resource.SyncMcpResourceMethodCallback;
-
+import org.springaicommunity.mcp.provider.McpProviderUtils;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.util.Assert;
 import reactor.core.publisher.Mono;
@@ -50,6 +52,11 @@ public class SyncMcpResourceProvider {
 					var resourceAnnotation = mcpResourceMethod.getAnnotation(McpResource.class);
 
 					var uri = resourceAnnotation.uri();
+
+					if (McpProviderUtils.isUriTemplate(uri)) {
+						return null;
+					}
+
 					var name = getName(mcpResourceMethod, resourceAnnotation);
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
@@ -69,6 +76,50 @@ public class SyncMcpResourceProvider {
 
 					return new SyncResourceSpecification(mcpResource, methodCallback);
 				})
+				.filter(Objects::nonNull)
+				.toList())
+			.flatMap(List::stream)
+			.toList();
+
+		return methodCallbacks;
+	}
+
+	public List<SyncResourceTemplateSpecification> getResourceTemplateSpecifications() {
+
+		List<SyncResourceTemplateSpecification> methodCallbacks = this.resourceObjects.stream()
+			.map(resourceObject -> Stream.of(this.doGetClassMethods(resourceObject))
+				.filter(resourceMethod -> resourceMethod.isAnnotationPresent(McpResource.class))
+				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
+				.map(mcpResourceMethod -> {
+					var resourceAnnotation = mcpResourceMethod.getAnnotation(McpResource.class);
+
+					var uri = resourceAnnotation.uri();
+
+					if (!McpProviderUtils.isUriTemplate(uri)) {
+						return null;
+					}
+
+					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var description = resourceAnnotation.description();
+					var mimeType = resourceAnnotation.mimeType();
+
+					var mcpResourceTemplate = McpSchema.ResourceTemplate.builder()
+						.uri(uri)
+						.name(name)
+						.description(description)
+						.mimeType(mimeType)
+						.build();
+
+					var methodCallback = SyncMcpResourceMethodCallback.builder()
+						.method(mcpResourceMethod)
+						.bean(resourceObject)
+						.resource(mcpResourceTemplate)
+						.build();
+
+					return new SyncResourceTemplateSpecification(mcpResourceTemplate, methodCallback);
+				})
+				.filter(Objects::nonNull)
 				.toList())
 			.flatMap(List::stream)
 			.toList();

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProvider.java
@@ -18,6 +18,7 @@ package org.springaicommunity.mcp.provider.resource;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
@@ -25,7 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.method.resource.SyncStatelessMcpResourceMethodCallback;
-
+import org.springaicommunity.mcp.provider.McpProviderUtils;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceTemplateSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceSpecification;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -75,6 +77,11 @@ public class SyncStatelessMcpResourceProvider {
 					var resourceAnnotation = doGetMcpResourceAnnotation(mcpResourceMethod);
 
 					var uri = resourceAnnotation.uri();
+
+					if (McpProviderUtils.isUriTemplate(uri)) {
+						return null;
+					}
+
 					var name = getName(mcpResourceMethod, resourceAnnotation);
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
@@ -97,6 +104,58 @@ public class SyncStatelessMcpResourceProvider {
 
 					return resourceSpec;
 				})
+				.filter(Objects::nonNull)
+				.toList())
+			.flatMap(List::stream)
+			.toList();
+
+		if (resourceSpecs.isEmpty()) {
+			logger.warn("No resource methods found in the provided resource objects: {}", this.resourceObjects);
+		}
+
+		return resourceSpecs;
+	}
+
+	public List<SyncResourceTemplateSpecification> getResourceTemplateSpecifications() {
+
+		List<SyncResourceTemplateSpecification> resourceSpecs = this.resourceObjects.stream()
+			.map(resourceObject -> Stream.of(doGetClassMethods(resourceObject))
+				.filter(method -> method.isAnnotationPresent(McpResource.class))
+				.filter(method -> !Mono.class.isAssignableFrom(method.getReturnType()))
+				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
+				.map(mcpResourceMethod -> {
+
+					var resourceAnnotation = doGetMcpResourceAnnotation(mcpResourceMethod);
+
+					var uri = resourceAnnotation.uri();
+
+					if (!McpProviderUtils.isUriTemplate(uri)) {
+						return null;
+					}
+
+					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var description = resourceAnnotation.description();
+					var mimeType = resourceAnnotation.mimeType();
+
+					var mcpResource = McpSchema.ResourceTemplate.builder()
+						.uri(uri)
+						.name(name)
+						.description(description)
+						.mimeType(mimeType)
+						.build();
+
+					BiFunction<McpTransportContext, ReadResourceRequest, ReadResourceResult> methodCallback = SyncStatelessMcpResourceMethodCallback
+						.builder()
+						.method(mcpResourceMethod)
+						.bean(resourceObject)
+						.resource(mcpResource)
+						.build();
+
+					var resourceSpec = new SyncResourceTemplateSpecification(mcpResource, methodCallback);
+
+					return resourceSpec;
+				})
+				.filter(Objects::nonNull)
 				.toList())
 			.flatMap(List::stream)
 			.toList();

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncMcpToolProvider.java
@@ -34,7 +34,7 @@ import org.springaicommunity.mcp.method.tool.ReactiveUtils;
 import org.springaicommunity.mcp.method.tool.ReturnMode;
 import org.springaicommunity.mcp.method.tool.utils.ClassUtils;
 import org.springaicommunity.mcp.method.tool.utils.JsonSchemaGenerator;
-import org.springaicommunity.mcp.provider.ProvidrerUtils;
+import org.springaicommunity.mcp.provider.McpProviderUtils;
 import reactor.core.publisher.Mono;
 
 /**
@@ -63,7 +63,7 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 		List<AsyncToolSpecification> toolSpecs = this.toolObjects.stream()
 			.map(toolObject -> Stream.of(this.doGetClassMethods(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
-				.filter(ProvidrerUtils.isReactiveReturnType)
+				.filter(McpProviderUtils.isReactiveReturnType)
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolMethod -> {
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -35,7 +35,7 @@ import org.springaicommunity.mcp.method.tool.ReactiveUtils;
 import org.springaicommunity.mcp.method.tool.ReturnMode;
 import org.springaicommunity.mcp.method.tool.utils.ClassUtils;
 import org.springaicommunity.mcp.method.tool.utils.JsonSchemaGenerator;
-import org.springaicommunity.mcp.provider.ProvidrerUtils;
+import org.springaicommunity.mcp.provider.McpProviderUtils;
 import reactor.core.publisher.Mono;
 
 /**
@@ -68,7 +68,7 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 		List<AsyncToolSpecification> toolSpecs = this.toolObjects.stream()
 			.map(toolObject -> Stream.of(doGetClassMethods(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
-				.filter(ProvidrerUtils.isReactiveReturnType)
+				.filter(McpProviderUtils.isReactiveReturnType)
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolMethod -> {
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncMcpToolProvider.java
@@ -33,7 +33,7 @@ import org.springaicommunity.mcp.method.tool.ReturnMode;
 import org.springaicommunity.mcp.method.tool.SyncMcpToolMethodCallback;
 import org.springaicommunity.mcp.method.tool.utils.ClassUtils;
 import org.springaicommunity.mcp.method.tool.utils.JsonSchemaGenerator;
-import org.springaicommunity.mcp.provider.ProvidrerUtils;
+import org.springaicommunity.mcp.provider.McpProviderUtils;
 
 /**
  * @author Christian Tzolov
@@ -61,7 +61,7 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 		List<SyncToolSpecification> toolSpecs = this.toolObjects.stream()
 			.map(toolObject -> Stream.of(this.doGetClassMethods(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
-				.filter(ProvidrerUtils.isNotReactiveReturnType)
+				.filter(McpProviderUtils.isNotReactiveReturnType)
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolMethod -> {
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProvider.java
@@ -34,7 +34,7 @@ import org.springaicommunity.mcp.method.tool.ReturnMode;
 import org.springaicommunity.mcp.method.tool.SyncStatelessMcpToolMethodCallback;
 import org.springaicommunity.mcp.method.tool.utils.ClassUtils;
 import org.springaicommunity.mcp.method.tool.utils.JsonSchemaGenerator;
-import org.springaicommunity.mcp.provider.ProvidrerUtils;
+import org.springaicommunity.mcp.provider.McpProviderUtils;
 
 /**
  * Provider for synchronous stateless MCP tool methods.
@@ -65,7 +65,7 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 		List<SyncToolSpecification> toolSpecs = this.toolObjects.stream()
 			.map(toolObject -> Stream.of(this.doGetClassMethods(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
-				.filter(ProvidrerUtils.isNotReactiveReturnType)
+				.filter(McpProviderUtils.isNotReactiveReturnType)
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolMethod -> {
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/AsyncMcpResourceProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/AsyncMcpResourceProviderTests.java
@@ -16,23 +16,23 @@
 
 package org.springaicommunity.mcp.provider.resource;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-
 import java.util.List;
-
-import org.junit.jupiter.api.Test;
-import org.springaicommunity.mcp.annotation.McpResource;
 
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceTemplateSpecification;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import org.junit.jupiter.api.Test;
+import org.springaicommunity.mcp.annotation.McpResource;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link AsyncMcpResourceProvider}.
@@ -65,12 +65,14 @@ public class AsyncMcpResourceProviderTests {
 		List<AsyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
 
 		assertThat(resourceSpecs).isNotNull();
-		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs).hasSize(0);
 
-		AsyncResourceSpecification resourceSpec = resourceSpecs.get(0);
-		assertThat(resourceSpec.resource().uri()).isEqualTo("test://resource/{id}");
-		assertThat(resourceSpec.resource().name()).isEqualTo("test-resource");
-		assertThat(resourceSpec.resource().description()).isEqualTo("A test resource");
+		var resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		AsyncResourceTemplateSpecification resourceSpec = resourceTemplateSpecs.get(0);
+		assertThat(resourceSpec.resourceTemplate().uriTemplate()).isEqualTo("test://resource/{id}");
+		assertThat(resourceSpec.resourceTemplate().name()).isEqualTo("test-resource");
+		assertThat(resourceSpec.resourceTemplate().description()).isEqualTo("A test resource");
 		assertThat(resourceSpec.readHandler()).isNotNull();
 
 		// Test that the handler works
@@ -280,15 +282,19 @@ public class AsyncMcpResourceProviderTests {
 		AsyncMcpResourceProvider provider = new AsyncMcpResourceProvider(List.of(resourceObject));
 
 		List<AsyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
+		assertThat(resourceSpecs).hasSize(0);
 
-		assertThat(resourceSpecs).hasSize(1);
-		assertThat(resourceSpecs.get(0).resource().uri()).isEqualTo("variable://resource/{id}/{type}");
-		assertThat(resourceSpecs.get(0).resource().name()).isEqualTo("variable-resource");
+		var resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		assertThat(resourceTemplateSpecs).hasSize(1);
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().uriTemplate())
+			.isEqualTo("variable://resource/{id}/{type}");
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().name()).isEqualTo("variable-resource");
 
 		// Test that the handler works with URI variables
 		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
 		ReadResourceRequest request = new ReadResourceRequest("variable://resource/123/document");
-		Mono<ReadResourceResult> result = resourceSpecs.get(0).readHandler().apply(exchange, request);
+		Mono<ReadResourceResult> result = resourceTemplateSpecs.get(0).readHandler().apply(exchange, request);
 
 		StepVerifier.create(result).assertNext(readResult -> {
 			assertThat(readResult.contents()).hasSize(1);

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProviderTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpResource;
 
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncResourceTemplateSpecification;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
@@ -66,12 +67,14 @@ public class AsyncStatelessMcpResourceProviderTests {
 		List<AsyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
 
 		assertThat(resourceSpecs).isNotNull();
-		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs).hasSize(0);
 
-		AsyncResourceSpecification resourceSpec = resourceSpecs.get(0);
-		assertThat(resourceSpec.resource().uri()).isEqualTo("test://resource/{id}");
-		assertThat(resourceSpec.resource().name()).isEqualTo("test-resource");
-		assertThat(resourceSpec.resource().description()).isEqualTo("A test resource");
+		var resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		AsyncResourceTemplateSpecification resourceSpec = resourceTemplateSpecs.get(0);
+		assertThat(resourceSpec.resourceTemplate().uriTemplate()).isEqualTo("test://resource/{id}");
+		assertThat(resourceSpec.resourceTemplate().name()).isEqualTo("test-resource");
+		assertThat(resourceSpec.resourceTemplate().description()).isEqualTo("A test resource");
 		assertThat(resourceSpec.readHandler()).isNotNull();
 
 		// Test that the handler works
@@ -282,15 +285,18 @@ public class AsyncStatelessMcpResourceProviderTests {
 		AsyncStatelessMcpResourceProvider provider = new AsyncStatelessMcpResourceProvider(List.of(resourceObject));
 
 		List<AsyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
+		assertThat(resourceSpecs).hasSize(0);
 
-		assertThat(resourceSpecs).hasSize(1);
-		assertThat(resourceSpecs.get(0).resource().uri()).isEqualTo("variable://resource/{id}/{type}");
-		assertThat(resourceSpecs.get(0).resource().name()).isEqualTo("variable-resource");
+		var resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().uriTemplate())
+			.isEqualTo("variable://resource/{id}/{type}");
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().name()).isEqualTo("variable-resource");
 
 		// Test that the handler works with URI variables
 		McpTransportContext context = mock(McpTransportContext.class);
 		ReadResourceRequest request = new ReadResourceRequest("variable://resource/123/document");
-		Mono<ReadResourceResult> result = resourceSpecs.get(0).readHandler().apply(context, request);
+		Mono<ReadResourceResult> result = resourceTemplateSpecs.get(0).readHandler().apply(context, request);
 
 		StepVerifier.create(result).assertNext(readResult -> {
 			assertThat(readResult.contents()).hasSize(1);

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/SyncMcpResourceProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/SyncMcpResourceProviderTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpResource;
 
 import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
@@ -64,18 +65,20 @@ public class SyncMcpResourceProviderTests {
 		List<SyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
 
 		assertThat(resourceSpecs).isNotNull();
-		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs).hasSize(0);
 
-		SyncResourceSpecification resourceSpec = resourceSpecs.get(0);
-		assertThat(resourceSpec.resource().uri()).isEqualTo("test://resource/{id}");
-		assertThat(resourceSpec.resource().name()).isEqualTo("test-resource");
-		assertThat(resourceSpec.resource().description()).isEqualTo("A test resource");
-		assertThat(resourceSpec.readHandler()).isNotNull();
+		List<SyncResourceTemplateSpecification> resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		SyncResourceTemplateSpecification resourceTemplateSpec = resourceTemplateSpecs.get(0);
+		assertThat(resourceTemplateSpec.resourceTemplate().uriTemplate()).isEqualTo("test://resource/{id}");
+		assertThat(resourceTemplateSpec.resourceTemplate().name()).isEqualTo("test-resource");
+		assertThat(resourceTemplateSpec.resourceTemplate().description()).isEqualTo("A test resource");
+		assertThat(resourceTemplateSpec.readHandler()).isNotNull();
 
 		// Test that the handler works
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
 		ReadResourceRequest request = new ReadResourceRequest("test://resource/123");
-		ReadResourceResult result = resourceSpec.readHandler().apply(exchange, request);
+		ReadResourceResult result = resourceTemplateSpec.readHandler().apply(exchange, request);
 
 		assertThat(result.contents()).hasSize(1);
 		ResourceContents content = result.contents().get(0);
@@ -278,14 +281,20 @@ public class SyncMcpResourceProviderTests {
 
 		List<SyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
 
-		assertThat(resourceSpecs).hasSize(1);
-		assertThat(resourceSpecs.get(0).resource().uri()).isEqualTo("variable://resource/{id}/{type}");
-		assertThat(resourceSpecs.get(0).resource().name()).isEqualTo("variable-resource");
+		assertThat(resourceSpecs).hasSize(0);
+
+		List<SyncResourceTemplateSpecification> resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		assertThat(resourceTemplateSpecs).hasSize(1);
+
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().uriTemplate())
+			.isEqualTo("variable://resource/{id}/{type}");
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().name()).isEqualTo("variable-resource");
 
 		// Test that the handler works with URI variables
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
 		ReadResourceRequest request = new ReadResourceRequest("variable://resource/123/document");
-		ReadResourceResult result = resourceSpecs.get(0).readHandler().apply(exchange, request);
+		ReadResourceResult result = resourceTemplateSpecs.get(0).readHandler().apply(exchange, request);
 
 		assertThat(result.contents()).hasSize(1);
 		ResourceContents content = result.contents().get(0);

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProviderTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpResource;
 
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceTemplateSpecification;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
@@ -65,18 +66,22 @@ public class SyncStatelessMcpResourceProviderTests {
 		List<SyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
 
 		assertThat(resourceSpecs).isNotNull();
-		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs).hasSize(0);
 
-		SyncResourceSpecification resourceSpec = resourceSpecs.get(0);
-		assertThat(resourceSpec.resource().uri()).isEqualTo("test://resource/{id}");
-		assertThat(resourceSpec.resource().name()).isEqualTo("test-resource");
-		assertThat(resourceSpec.resource().description()).isEqualTo("A test resource");
-		assertThat(resourceSpec.readHandler()).isNotNull();
+		List<SyncResourceTemplateSpecification> resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		assertThat(resourceTemplateSpecs).hasSize(1);
+
+		SyncResourceTemplateSpecification resourceTemplateSpec = resourceTemplateSpecs.get(0);
+		assertThat(resourceTemplateSpec.resourceTemplate().uriTemplate()).isEqualTo("test://resource/{id}");
+		assertThat(resourceTemplateSpec.resourceTemplate().name()).isEqualTo("test-resource");
+		assertThat(resourceTemplateSpec.resourceTemplate().description()).isEqualTo("A test resource");
+		assertThat(resourceTemplateSpec.readHandler()).isNotNull();
 
 		// Test that the handler works
 		McpTransportContext context = mock(McpTransportContext.class);
 		ReadResourceRequest request = new ReadResourceRequest("test://resource/123");
-		ReadResourceResult result = resourceSpec.readHandler().apply(context, request);
+		ReadResourceResult result = resourceTemplateSpec.readHandler().apply(context, request);
 
 		assertThat(result).isNotNull();
 		assertThat(result.contents()).hasSize(1);
@@ -281,14 +286,19 @@ public class SyncStatelessMcpResourceProviderTests {
 
 		List<SyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
 
-		assertThat(resourceSpecs).hasSize(1);
-		assertThat(resourceSpecs.get(0).resource().uri()).isEqualTo("variable://resource/{id}/{type}");
-		assertThat(resourceSpecs.get(0).resource().name()).isEqualTo("variable-resource");
+		assertThat(resourceSpecs).hasSize(0);
+
+		var resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		assertThat(resourceTemplateSpecs).hasSize(1);
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().uriTemplate())
+			.isEqualTo("variable://resource/{id}/{type}");
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().name()).isEqualTo("variable-resource");
 
 		// Test that the handler works with URI variables
 		McpTransportContext context = mock(McpTransportContext.class);
 		ReadResourceRequest request = new ReadResourceRequest("variable://resource/123/document");
-		ReadResourceResult result = resourceSpecs.get(0).readHandler().apply(context, request);
+		ReadResourceResult result = resourceTemplateSpecs.get(0).readHandler().apply(context, request);
 
 		assertThat(result).isNotNull();
 		assertThat(result.contents()).hasSize(1);

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 
-		<mcp.java.sdk.version>0.13.1</mcp.java.sdk.version>
+		<mcp.java.sdk.version>0.14.0-SNAPSHOT</mcp.java.sdk.version>
 
 		<jsonschema.version>4.38.0</jsonschema.version>
 		<swagger-annotations.version>2.2.36</swagger-annotations.version>


### PR DESCRIPTION
DEPENDS ON https://github.com/modelcontextprotocol/java-sdk/pull/576

- Add getResourceTemplateSpecifications() methods to all resource providers
- Separate regular resources from resource templates based on URI template detection
- Rename ProvidrerUtils to McpProviderUtils (fix typo)
- Filter resources with URI templates into separate template specifications
- Update tests to verify resource template handling
- Upgrade MCP Java SDK from 0.13.1 to 0.14.0-SNAPSHOT

This change enables proper handling of MCP resource templates (URIs with variables like {id}) while maintaining backward compatibility for regular resources.