### PR TITLE
refactor: fix typo in SyncMcpLoggingProvider class name

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/logging/SyncMcpLoggingProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/logging/SyncMcpLoggingProvider.java
@@ -56,10 +56,8 @@ import reactor.core.publisher.Mono;
  * @see McpLogging
  * @see SyncMcpLoggingMethodCallback
  * @see LoggingMessageNotification
- * @deprecated Use {@link SyncMcpLoggingProvider} instead.
  */
-@Deprecated
-public class SyncMcpLogginProvider {
+public class SyncMcpLoggingProvider {
 
 	private final List<Object> loggingConsumerObjects;
 
@@ -68,7 +66,7 @@ public class SyncMcpLogginProvider {
 	 * @param loggingConsumerObjects the objects containing methods annotated with
 	 * {@link McpLogging}
 	 */
-	public SyncMcpLogginProvider(List<Object> loggingConsumerObjects) {
+	public SyncMcpLoggingProvider(List<Object> loggingConsumerObjects) {
 		Assert.notNull(loggingConsumerObjects, "loggingConsumerObjects cannot be null");
 		this.loggingConsumerObjects = loggingConsumerObjects;
 	}

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/logging/SyncMcpLoggingProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/logging/SyncMcpLoggingProviderTests.java
@@ -17,7 +17,7 @@ import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
 import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
 
 /**
- * Tests for {@link SyncMcpLogginProvider}.
+ * Tests for {@link SyncMcpLoggingProvider}.
  *
  * @author Christian Tzolov
  */
@@ -60,7 +60,7 @@ public class SyncMcpLoggingProviderTests {
 	@Test
 	void testGetLoggingConsumers() {
 		LoggingHandler loggingHandler = new LoggingHandler();
-		SyncMcpLogginProvider provider = new SyncMcpLogginProvider(List.of(loggingHandler));
+		SyncMcpLoggingProvider provider = new SyncMcpLoggingProvider(List.of(loggingHandler));
 
 		List<SyncLoggingSpecification> specifications = provider.getLoggingSpecifications();
 		List<Consumer<LoggingMessageNotification>> consumers = specifications.stream()
@@ -89,7 +89,7 @@ public class SyncMcpLoggingProviderTests {
 
 	@Test
 	void testEmptyList() {
-		SyncMcpLogginProvider provider = new SyncMcpLogginProvider(List.of());
+		SyncMcpLoggingProvider provider = new SyncMcpLoggingProvider(List.of());
 
 		List<Consumer<LoggingMessageNotification>> consumers = provider.getLoggingSpecifications()
 			.stream()
@@ -103,7 +103,7 @@ public class SyncMcpLoggingProviderTests {
 	void testMultipleObjects() {
 		LoggingHandler handler1 = new LoggingHandler();
 		LoggingHandler handler2 = new LoggingHandler();
-		SyncMcpLogginProvider provider = new SyncMcpLogginProvider(List.of(handler1, handler2));
+		SyncMcpLoggingProvider provider = new SyncMcpLoggingProvider(List.of(handler1, handler2));
 
 		List<Consumer<LoggingMessageNotification>> consumers = provider.getLoggingSpecifications()
 			.stream()


### PR DESCRIPTION
- Rename SyncMcpLogginProvider to SyncMcpLoggingProvider (fix typo: Loggin -> Logging)
- Add @Deprecated annotation to old class with reference to new class
- Update all test references to use the corrected class name
- New class maintains identical functionality with corrected naming