### PR TITLE
refactor: extract JSON conversion utilities and enhance elicitation support

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/DefaultMcpSyncRequestContext.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/DefaultMcpSyncRequestContext.java
@@ -10,8 +10,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -80,7 +78,7 @@ public class DefaultMcpSyncRequestContext implements McpSyncRequestContext {
 		}
 
 		return Optional.of(new StructuredElicitResult<>(elicitResult.get().action(),
-				convertMapToType(elicitResult.get().content(), type), elicitResult.get().meta()));
+				JsonParser.convertMapToType(elicitResult.get().content(), type), elicitResult.get().meta()));
 	}
 
 	@Override
@@ -95,7 +93,7 @@ public class DefaultMcpSyncRequestContext implements McpSyncRequestContext {
 		}
 
 		return Optional.of(new StructuredElicitResult<>(elicitResult.get().action(),
-				convertMapToType(elicitResult.get().content(), type), elicitResult.get().meta()));
+				JsonParser.convertMapToType(elicitResult.get().content(), type), elicitResult.get().meta()));
 	}
 
 	@Override
@@ -114,7 +112,7 @@ public class DefaultMcpSyncRequestContext implements McpSyncRequestContext {
 		}
 
 		return Optional.of(new StructuredElicitResult<>(elicitResult.get().action(),
-				convertMapToType(elicitResult.get().content(), returnType), elicitResult.get().meta()));
+				JsonParser.convertMapToType(elicitResult.get().content(), returnType), elicitResult.get().meta()));
 	}
 
 	@Override
@@ -134,7 +132,7 @@ public class DefaultMcpSyncRequestContext implements McpSyncRequestContext {
 		}
 
 		return Optional.of(new StructuredElicitResult<>(elicitResult.get().action(),
-				convertMapToType(elicitResult.get().content(), returnType), elicitResult.get().meta()));
+				JsonParser.convertMapToType(elicitResult.get().content(), returnType), elicitResult.get().meta()));
 	}
 
 	@Override
@@ -157,6 +155,9 @@ public class DefaultMcpSyncRequestContext implements McpSyncRequestContext {
 		Assert.hasText(message, "Elicitation message must not be empty");
 		Assert.notNull(type, "Elicitation response type must not be null");
 
+		// TODO add validation for the Elicitation Schema
+		// https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation#supported-schema-types
+
 		Map<String, Object> schema = typeSchemaCache.computeIfAbsent(type, t -> this.generateElicitSchema(t));
 
 		return this.elicit(ElicitRequest.builder().message(message).requestedSchema(schema).meta(meta).build());
@@ -167,18 +168,6 @@ public class DefaultMcpSyncRequestContext implements McpSyncRequestContext {
 		// remove $schema as elicitation schema does not support it
 		schema.remove("$schema");
 		return schema;
-	}
-
-	private static <T> T convertMapToType(Map<String, Object> map, Class<T> targetType) {
-		ObjectMapper mapper = new ObjectMapper();
-		JavaType javaType = mapper.getTypeFactory().constructType(targetType);
-		return mapper.convertValue(map, javaType);
-	}
-
-	private static <T> T convertMapToType(Map<String, Object> map, TypeReference<T> targetType) {
-		ObjectMapper mapper = new ObjectMapper();
-		JavaType javaType = mapper.getTypeFactory().constructType(targetType);
-		return mapper.convertValue(map, javaType);
 	}
 
 	// Sampling

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/McpRequestContextTypes.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/McpRequestContextTypes.java
@@ -20,6 +20,7 @@ import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
 import io.modelcontextprotocol.spec.McpSchema.ResourceLink;
 import io.modelcontextprotocol.spec.McpSchema.SamplingMessage;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.util.Assert;
 
 /**
  * @author Christian Tzolov
@@ -110,6 +111,11 @@ public interface McpRequestContextTypes<ET> {
 
 		ProgressSpec meta(String k, Object v);
 
+		default ProgressSpec percentage(int percentage) {
+			Assert.isTrue(percentage >= 0 && percentage <= 100, "Percentage must be between 0 and 100");
+			return this.progress(percentage).total(100.0);
+		}
+
 	}
 
 	// --------------------------------------
@@ -143,6 +149,7 @@ public interface McpRequestContextTypes<ET> {
 
 	ClientCapabilities clientCapabilities();
 
+	// TODO: Should we rename it to meta()?
 	Map<String, Object> requestMeta();
 
 	McpTransportContext transportContext();

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/McpSyncRequestContext.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/McpSyncRequestContext.java
@@ -51,7 +51,7 @@ public interface McpSyncRequestContext extends McpRequestContextTypes<McpSyncSer
 	// --------------------------------------
 	// Progress
 	// --------------------------------------
-	void progress(int progress);
+	void progress(int percentage);
 
 	void progress(Consumer<ProgressSpec> progressSpec);
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/StructuredElicitResultBuilder.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/StructuredElicitResultBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult.Action;
+import io.modelcontextprotocol.util.Assert;
+
+/**
+ * Builder for {@link StructuredElicitResult}.
+ *
+ * @param <T> the type of the structured content
+ * @author Christian Tzolov
+ */
+public class StructuredElicitResultBuilder<T> {
+
+	private Action action = Action.ACCEPT;
+
+	private T structuredContent;
+
+	private Map<String, Object> meta = new HashMap<>();
+
+	/**
+	 * Private constructor to enforce builder pattern usage.
+	 */
+	private StructuredElicitResultBuilder() {
+		this.meta = new HashMap<>();
+	}
+
+	/**
+	 * Creates a new builder instance.
+	 * @param <T> the type of the structured content
+	 * @return a new builder instance
+	 */
+	public static <T> StructuredElicitResultBuilder<T> builder() {
+		return new StructuredElicitResultBuilder<>();
+	}
+
+	/**
+	 * Sets the action.
+	 * @param action the action to set
+	 * @return this builder instance
+	 */
+	public StructuredElicitResultBuilder<T> action(Action action) {
+		Assert.notNull(action, "Action must not be null");
+		this.action = action;
+		return this;
+	}
+
+	/**
+	 * Sets the structured content.
+	 * @param structuredContent the structured content to set
+	 * @return this builder instance
+	 */
+	public StructuredElicitResultBuilder<T> structuredContent(T structuredContent) {
+		this.structuredContent = structuredContent;
+		return this;
+	}
+
+	/**
+	 * Sets the meta map.
+	 * @param meta the meta map to set
+	 * @return this builder instance
+	 */
+	public StructuredElicitResultBuilder<T> meta(Map<String, Object> meta) {
+		this.meta = meta != null ? new HashMap<>(meta) : new HashMap<>();
+		return this;
+	}
+
+	/**
+	 * Adds a single meta entry.
+	 * @param key the meta key
+	 * @param value the meta value
+	 * @return this builder instance
+	 */
+	public StructuredElicitResultBuilder<T> addMeta(String key, Object value) {
+		this.meta.put(key, value);
+		return this;
+	}
+
+	/**
+	 * Builds the {@link StructuredElicitResult} instance.
+	 * @return a new StructuredElicitResult instance
+	 */
+	public StructuredElicitResult<T> build() {
+		return new StructuredElicitResult<>(this.action, this.structuredContent, this.meta);
+	}
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/JsonParser.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/JsonParser.java
@@ -18,10 +18,12 @@ package org.springaicommunity.mcp.method.tool.utils;
 
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
+import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -33,6 +35,14 @@ import io.modelcontextprotocol.util.Assert;
  * Utilities to perform parsing operations between JSON and Java.
  */
 public final class JsonParser {
+
+	private static TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<Map<String, Object>>() {
+	};
+
+	public static Map<String, Object> convertObjectToMap(Object object) {
+		Assert.notNull(object, "object cannot be null");
+		return OBJECT_MAPPER.convertValue(object, MAP_TYPE_REF);
+	}
 
 	private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
 		.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
@@ -169,6 +179,16 @@ public final class JsonParser {
 
 		String json = JsonParser.toJson(value);
 		return JsonParser.fromJson(json, javaType);
+	}
+
+	public static <T> T convertMapToType(Map<String, Object> map, Class<T> targetType) {
+		JavaType javaType = OBJECT_MAPPER.getTypeFactory().constructType(targetType);
+		return OBJECT_MAPPER.convertValue(map, javaType);
+	}
+
+	public static <T> T convertMapToType(Map<String, Object> map, TypeReference<T> targetType) {
+		JavaType javaType = OBJECT_MAPPER.getTypeFactory().constructType(targetType);
+		return OBJECT_MAPPER.convertValue(map, javaType);
 	}
 
 }

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/elicitation/SyncMcpElicitationProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/elicitation/SyncMcpElicitationProvider.java
@@ -27,6 +27,7 @@ import io.modelcontextprotocol.util.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.context.StructuredElicitResult;
 import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
 import org.springaicommunity.mcp.method.elicitation.SyncMcpElicitationMethodCallback;
 import org.springaicommunity.mcp.provider.McpProviderUtils;
@@ -87,7 +88,8 @@ public class SyncMcpElicitationProvider {
 			.map(elicitationObject -> Stream.of(doGetClassMethods(elicitationObject))
 				.filter(method -> method.isAnnotationPresent(McpElicitation.class))
 				.filter(McpProviderUtils.filterReactiveReturnTypeMethod())
-				.filter(method -> ElicitResult.class.isAssignableFrom(method.getReturnType()))
+				.filter(method -> ElicitResult.class.isAssignableFrom(method.getReturnType())
+						|| StructuredElicitResult.class.isAssignableFrom(method.getReturnType()))
 				.filter(method -> method.getParameterCount() == 1
 						&& ElicitRequest.class.isAssignableFrom(method.getParameterTypes()[0]))
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))


### PR DESCRIPTION
- Extract convertMapToType methods to JsonParser utility class
- Add convertObjectToMap method to JsonParser for bidirectional conversion
- Add StructuredElicitResult support in elicitation method callbacks
  - Update AsyncMcpElicitationMethodCallback to handle Mono<StructuredElicitResult>
  - Update SyncMcpElicitationMethodCallback to handle StructuredElicitResult
  - Update providers to filter for StructuredElicitResult return types
- Add StructuredElicitResultBuilder for fluent construction
- Add percentage() convenience method to ProgressSpec
- Add TODO comments for elicitation schema validation
- Update method validation error messages for clarity
- Remove unused Jackson imports from context classes
- Update test expectations for new return type requirements