### PR TITLE
fix:#61:outputSchema do not contain description

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/JsonSchemaGenerator.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/JsonSchemaGenerator.java
@@ -184,15 +184,7 @@ public class JsonSchemaGenerator {
 	}
 
 	private static String internalGenerateFromClass(Class<?> clazz) {
-		SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12,
-				OptionPreset.PLAIN_JSON);
-		SchemaGeneratorConfig config = configBuilder.with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
-			.without(Option.FLATTENED_ENUMS_FROM_TOSTRING)
-			.build();
-
-		SchemaGenerator generator = new SchemaGenerator(config);
-		JsonNode jsonSchema = generator.generateSchema(clazz);
-		return jsonSchema.toPrettyString();
+		return TYPE_SCHEMA_GENERATOR.generateSchema(clazz).toPrettyString();
 	}
 
 	public static String generateFromType(Type type) {
@@ -201,15 +193,7 @@ public class JsonSchemaGenerator {
 	}
 
 	private static String internalGenerateFromType(Type type) {
-		SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12,
-				OptionPreset.PLAIN_JSON);
-		SchemaGeneratorConfig config = configBuilder.with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
-			.without(Option.FLATTENED_ENUMS_FROM_TOSTRING)
-			.build();
-
-		SchemaGenerator generator = new SchemaGenerator(config);
-		JsonNode jsonSchema = generator.generateSchema(type);
-		return jsonSchema.toPrettyString();
+		return TYPE_SCHEMA_GENERATOR.generateSchema(type).toPrettyString();
 	}
 
 	/**

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/tool/SyncMcpToolProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/tool/SyncMcpToolProviderTests.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpTool;
 
@@ -586,7 +588,9 @@ public class SyncMcpToolProviderTests {
 	void testToolWithOutputSchemaGeneration() {
 
 		// Define a custom result class
-		record CustomResult(String message, int count) {
+		record CustomResult(@JsonPropertyDescription("customResultMessage") @JsonProperty(required = false)
+							 String message,
+							@JsonProperty(required = true) int count) {
 		}
 
 		class OutputSchemaTool {
@@ -613,7 +617,7 @@ public class SyncMcpToolProviderTests {
 		assertThat(outputSchemaString).contains("message");
 		assertThat(outputSchemaString).contains("count");
 		assertThat(outputSchemaString).isEqualTo(
-				"{$schema=https://json-schema.org/draft/2020-12/schema, type=array, items={type=object, properties={count={type=integer, format=int32}, message={type=string}}}}");
+				"{$schema=https://json-schema.org/draft/2020-12/schema, type=array, items={type=object, properties={count={type=integer, format=int32}, message={type=string, description=customResultMessage}}, required=[count]}}");
 	}
 
 	@Test


### PR DESCRIPTION
fix:Invalid MCP tool output schema when using Jackson @JsonProperty annotation #61
fix：[@McpTool output schema generation ignores Jackson annotations](https://github.com/spring-projects/spring-ai/issues/4487)

According to the [MCP protocol specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema), the outputSchema should include 'description' and 'required'.

Use org.springaicommunity.mcp.method.tool.utils.JsonSchemaGenerator#TYPE_SCHEMA_GENERATOR to generate the outputSchema, so that the outputSchema includes description and required information.