### PR TITLE
refactor: improve bidirectional capability handling and error reporting

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/McpAsyncRequestContext.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/McpAsyncRequestContext.java
@@ -4,7 +4,6 @@
 
 package org.springaicommunity.mcp.context;
 
-import java.util.Map;
 import java.util.function.Consumer;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -27,11 +26,14 @@ public interface McpAsyncRequestContext extends McpRequestContextTypes<McpAsyncS
 	// --------------------------------------
 	// Roots
 	// --------------------------------------
+	Mono<Boolean> rootsEnabled();
+
 	Mono<ListRootsResult> roots();
 
 	// --------------------------------------
 	// Elicitation
 	// --------------------------------------
+	Mono<Boolean> elicitEnabled();
 
 	<T> Mono<StructuredElicitResult<T>> elicit(Class<T> type);
 
@@ -46,6 +48,8 @@ public interface McpAsyncRequestContext extends McpRequestContextTypes<McpAsyncS
 	// --------------------------------------
 	// Sampling
 	// --------------------------------------
+	Mono<Boolean> sampleEnabled();
+
 	Mono<CreateMessageResult> sample(String... messages);
 
 	Mono<CreateMessageResult> sample(Consumer<SamplingSpec> samplingSpec);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/McpSyncRequestContext.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/context/McpSyncRequestContext.java
@@ -24,29 +24,35 @@ public interface McpSyncRequestContext extends McpRequestContextTypes<McpSyncSer
 	// --------------------------------------
 	// Roots
 	// --------------------------------------
-	Optional<ListRootsResult> roots();
+	boolean rootsEnabled();
+
+	ListRootsResult roots();
 
 	// --------------------------------------
 	// Elicitation
 	// --------------------------------------
-	<T> Optional<StructuredElicitResult<T>> elicit(Class<T> type);
+	boolean elicitEnabled();
 
-	<T> Optional<StructuredElicitResult<T>> elicit(TypeReference<T> type);
+	<T> StructuredElicitResult<T> elicit(Class<T> type);
 
-	<T> Optional<StructuredElicitResult<T>> elicit(Consumer<ElicitationSpec> params, Class<T> returnType);
+	<T> StructuredElicitResult<T> elicit(TypeReference<T> type);
 
-	<T> Optional<StructuredElicitResult<T>> elicit(Consumer<ElicitationSpec> params, TypeReference<T> returnType);
+	<T> StructuredElicitResult<T> elicit(Consumer<ElicitationSpec> params, Class<T> returnType);
 
-	Optional<ElicitResult> elicit(ElicitRequest elicitRequest);
+	<T> StructuredElicitResult<T> elicit(Consumer<ElicitationSpec> params, TypeReference<T> returnType);
+
+	ElicitResult elicit(ElicitRequest elicitRequest);
 
 	// --------------------------------------
 	// Sampling
 	// --------------------------------------
-	Optional<CreateMessageResult> sample(String... messages);
+	boolean sampleEnabled();
 
-	Optional<CreateMessageResult> sample(Consumer<SamplingSpec> samplingSpec);
+	CreateMessageResult sample(String... messages);
 
-	Optional<CreateMessageResult> sample(CreateMessageRequest createMessageRequest);
+	CreateMessageResult sample(Consumer<SamplingSpec> samplingSpec);
+
+	CreateMessageResult sample(CreateMessageRequest createMessageRequest);
 
 	// --------------------------------------
 	// Progress

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractMcpToolMethodCallback.java
@@ -44,7 +44,7 @@ import org.springaicommunity.mcp.method.tool.utils.JsonParser;
  * McpSyncServerExchange, or McpAsyncServerExchange)
  * @author Christian Tzolov
  */
-public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestContextTypes> {
+public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestContextTypes<?>> {
 
 	protected final Method toolMethod;
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AsyncStatelessMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AsyncStatelessMcpToolMethodCallback.java
@@ -22,7 +22,6 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import org.springaicommunity.mcp.annotation.McpTool;
-import org.springaicommunity.mcp.context.DefaultMcpAsyncRequestContext;
 import org.springaicommunity.mcp.context.McpAsyncRequestContext;
 import reactor.core.publisher.Mono;
 
@@ -57,12 +56,8 @@ public final class AsyncStatelessMcpToolMethodCallback
 
 	@Override
 	protected McpAsyncRequestContext createRequestContext(McpTransportContext exchange, CallToolRequest request) {
-
-		return DefaultMcpAsyncRequestContext.builder()
-			.request(request)
-			.transportContext(exchange)
-			.stateless(true)
-			.build();
+		throw new UnsupportedOperationException(
+				"Stateless tool methods do not support McpAsyncRequestContext parameter.");
 	}
 
 	/**

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/SyncMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/SyncMcpToolMethodCallback.java
@@ -54,7 +54,6 @@ public final class SyncMcpToolMethodCallback
 
 	@Override
 	protected McpSyncRequestContext createRequestContext(McpSyncServerExchange exchange, CallToolRequest request) {
-
 		return DefaultMcpSyncRequestContext.builder().request(request).exchange(exchange).build();
 	}
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/SyncStatelessMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/SyncStatelessMcpToolMethodCallback.java
@@ -56,12 +56,8 @@ public final class SyncStatelessMcpToolMethodCallback
 
 	@Override
 	protected McpSyncRequestContext createRequestContext(McpTransportContext exchange, CallToolRequest request) {
-
-		return DefaultMcpSyncRequestContext.builder()
-			.request(request)
-			.transportContext(exchange)
-			.stateless(true)
-			.build();
+		throw new UnsupportedOperationException(
+				"Stateless tool methods do not support McpSyncRequestContext parameter.");
 	}
 
 	@Override

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/ConcurrentReferenceHashMap.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/utils/ConcurrentReferenceHashMap.java
@@ -672,7 +672,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V> implemen
 			return null;
 		}
 
-		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@SuppressWarnings({ "unchecked" })
 		private Reference<K, V>[] createReferenceArray(int size) {
 			return new Reference[size];
 		}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/AsyncStatelessMcpCompleteProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/AsyncStatelessMcpCompleteProvider.java
@@ -69,6 +69,7 @@ public class AsyncStatelessMcpCompleteProvider {
 			.map(completeObject -> Stream.of(doGetClassMethods(completeObject))
 				.filter(method -> method.isAnnotationPresent(McpComplete.class))
 				.filter(McpProviderUtils.filterNonReactiveReturnTypeMethod())
+				.filter(McpProviderUtils.filterMethodWithBidirectionalParameters())
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpCompleteMethod -> {
 					var completeAnnotation = mcpCompleteMethod.getAnnotation(McpComplete.class);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/SyncStatelessMcpCompleteProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/complete/SyncStatelessMcpCompleteProvider.java
@@ -68,6 +68,7 @@ public class SyncStatelessMcpCompleteProvider {
 			.map(completeObject -> Stream.of(doGetClassMethods(completeObject))
 				.filter(method -> method.isAnnotationPresent(McpComplete.class))
 				.filter(McpProviderUtils.filterReactiveReturnTypeMethod())
+				.filter(McpProviderUtils.filterMethodWithBidirectionalParameters())
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpCompleteMethod -> {
 					var completeAnnotation = mcpCompleteMethod.getAnnotation(McpComplete.class);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/AsyncStatelessMcpPromptProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/AsyncStatelessMcpPromptProvider.java
@@ -69,6 +69,7 @@ public class AsyncStatelessMcpPromptProvider {
 			.map(promptObject -> Stream.of(doGetClassMethods(promptObject))
 				.filter(method -> method.isAnnotationPresent(McpPrompt.class))
 				.filter(McpProviderUtils.filterNonReactiveReturnTypeMethod())
+				.filter(McpProviderUtils.filterMethodWithBidirectionalParameters())
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpPromptMethod -> {
 					var promptAnnotation = mcpPromptMethod.getAnnotation(McpPrompt.class);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/SyncStatelessMcpPromptProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/prompt/SyncStatelessMcpPromptProvider.java
@@ -68,6 +68,7 @@ public class SyncStatelessMcpPromptProvider {
 			.map(promptObject -> Stream.of(doGetClassMethods(promptObject))
 				.filter(method -> method.isAnnotationPresent(McpPrompt.class))
 				.filter(McpProviderUtils.filterReactiveReturnTypeMethod())
+				.filter(McpProviderUtils.filterMethodWithBidirectionalParameters())
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpPromptMethod -> {
 					var promptAnnotation = mcpPromptMethod.getAnnotation(McpPrompt.class);

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProvider.java
@@ -71,6 +71,7 @@ public class AsyncStatelessMcpResourceProvider {
 			.map(resourceObject -> Stream.of(doGetClassMethods(resourceObject))
 				.filter(method -> method.isAnnotationPresent(McpResource.class))
 				.filter(McpProviderUtils.filterNonReactiveReturnTypeMethod())
+				.filter(McpProviderUtils.filterMethodWithBidirectionalParameters())
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpResourceMethod -> {
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProvider.java
@@ -70,6 +70,7 @@ public class SyncStatelessMcpResourceProvider {
 			.map(resourceObject -> Stream.of(doGetClassMethods(resourceObject))
 				.filter(method -> method.isAnnotationPresent(McpResource.class))
 				.filter(McpProviderUtils.filterReactiveReturnTypeMethod())
+				.filter(McpProviderUtils.filterMethodWithBidirectionalParameters())
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpResourceMethod -> {
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -68,6 +68,7 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 			.map(toolObject -> Stream.of(doGetClassMethods(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
 				.filter(McpProviderUtils.filterNonReactiveReturnTypeMethod())
+				.filter(McpProviderUtils.filterMethodWithBidirectionalParameters())
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolMethod -> {
 

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/tool/SyncStatelessMcpToolProvider.java
@@ -65,6 +65,7 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 			.map(toolObject -> Stream.of(this.doGetClassMethods(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
 				.filter(McpProviderUtils.filterReactiveReturnTypeMethod())
+				.filter(McpProviderUtils.filterMethodWithBidirectionalParameters())
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
 				.map(mcpToolMethod -> {
 
@@ -106,8 +107,6 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 						title = toolName;
 					}
 					toolBuilder.title(title);
-
-					// ReactiveUtils.isReactiveReturnTypeOfCallToolResult(mcpToolMethod);
 
 					// Generate Output Schema from the method return type.
 					// Output schema is not generated for primitive types, void,

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/context/DefaultMcpAsyncRequestContextTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/context/DefaultMcpAsyncRequestContextTests.java
@@ -112,7 +112,10 @@ public class DefaultMcpAsyncRequestContextTests {
 	public void testRootsWhenNotSupported() {
 		when(exchange.getClientCapabilities()).thenReturn(null);
 
-		StepVerifier.create(context.roots()).verifyComplete();
+		StepVerifier.create(context.roots()).verifyErrorSatisfies(e -> {
+			assertThat(e).isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("Roots not supported by the client");
+		});
 	}
 
 	@Test
@@ -121,7 +124,11 @@ public class DefaultMcpAsyncRequestContextTests {
 		when(capabilities.roots()).thenReturn(null);
 		when(exchange.getClientCapabilities()).thenReturn(capabilities);
 
-		StepVerifier.create(context.roots()).verifyComplete();
+		StepVerifier.create(context.roots()).verifyErrorSatisfies(e -> {
+			assertThat(e).isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("Roots not supported by the client");
+		});
+
 	}
 
 	// Elicitation Tests
@@ -197,16 +204,16 @@ public class DefaultMcpAsyncRequestContextTests {
 
 	@Test
 	public void testElicitationWithNullTypeReference() {
-		assertThat(org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			context.elicit((TypeReference<?>) null);
-		})).hasMessageContaining("Elicitation response type must not be null");
+		assertThat(org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+				() -> context.elicit((TypeReference<?>) null)))
+			.hasMessageContaining("Elicitation response type must not be null");
 	}
 
 	@Test
 	public void testElicitationWithNullClassType() {
-		assertThat(org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			context.elicit((Class<?>) null);
-		})).hasMessageContaining("Elicitation response type must not be null");
+		assertThat(org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+				() -> context.elicit((Class<?>) null)))
+			.hasMessageContaining("Elicitation response type must not be null");
 	}
 
 	@Test
@@ -229,11 +236,11 @@ public class DefaultMcpAsyncRequestContextTests {
 	public void testElicitationReturnsEmptyWhenNotSupported() {
 		when(exchange.getClientCapabilities()).thenReturn(null);
 
-		Mono<StructuredElicitResult<Map<String, Object>>> result = context.elicit(e -> e.message("Test message"),
-				new TypeReference<Map<String, Object>>() {
-				});
-
-		StepVerifier.create(result).verifyComplete();
+		StepVerifier.create(context.elicit(e -> e.message("Test message"), new TypeReference<Map<String, Object>>() {
+		})).verifyErrorSatisfies(e -> {
+			assertThat(e).isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("Elicitation not supported by the client");
+		});
 	}
 
 	@Test
@@ -371,9 +378,10 @@ public class DefaultMcpAsyncRequestContextTests {
 			.requestedSchema(Map.of("type", "string"))
 			.build();
 
-		Mono<ElicitResult> result = context.elicit(elicitRequest);
-
-		StepVerifier.create(result).verifyComplete();
+		StepVerifier.create(context.elicit(elicitRequest)).verifyErrorSatisfies(e -> {
+			assertThat(e).isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("Elicitation not supported by the client");
+		});
 	}
 
 	// Sampling Tests
@@ -450,9 +458,10 @@ public class DefaultMcpAsyncRequestContextTests {
 			.maxTokens(500)
 			.build();
 
-		Mono<CreateMessageResult> result = context.sample(createRequest);
-
-		StepVerifier.create(result).verifyComplete();
+		StepVerifier.create(context.sample(createRequest)).verifyErrorSatisfies(e -> {
+			assertThat(e).isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("Sampling not supported by the client");
+		});
 	}
 
 	// Progress Tests

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/McpProviderUtilsTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/McpProviderUtilsTests.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.provider;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Predicate;
+
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.springaicommunity.mcp.context.McpAsyncRequestContext;
+import org.springaicommunity.mcp.context.McpSyncRequestContext;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link McpProviderUtils}.
+ *
+ * @author Christian Tzolov
+ */
+public class McpProviderUtilsTests {
+
+	// Test classes for method reflection tests
+	static class TestMethods {
+
+		public String nonReactiveMethod() {
+			return "test";
+		}
+
+		public Mono<String> monoMethod() {
+			return Mono.just("test");
+		}
+
+		public Flux<String> fluxMethod() {
+			return Flux.just("test");
+		}
+
+		public Publisher<String> publisherMethod() {
+			return Mono.just("test");
+		}
+
+		public void voidMethod() {
+		}
+
+		public List<String> listMethod() {
+			return List.of("test");
+		}
+
+		public String methodWithSyncContext(McpSyncRequestContext context) {
+			return "test";
+		}
+
+		public String methodWithAsyncContext(McpAsyncRequestContext context) {
+			return "test";
+		}
+
+		public String methodWithSyncExchange(McpSyncServerExchange exchange) {
+			return "test";
+		}
+
+		public String methodWithAsyncExchange(McpAsyncServerExchange exchange) {
+			return "test";
+		}
+
+		public String methodWithMultipleParams(String param1, McpSyncRequestContext context, int param2) {
+			return "test";
+		}
+
+		public String methodWithoutBidirectionalParams(String param1, int param2) {
+			return "test";
+		}
+
+	}
+
+	// URI Template Tests
+
+	@Test
+	public void testIsUriTemplateWithSimpleVariable() {
+		assertThat(McpProviderUtils.isUriTemplate("/api/{id}")).isTrue();
+	}
+
+	@Test
+	public void testIsUriTemplateWithMultipleVariables() {
+		assertThat(McpProviderUtils.isUriTemplate("/api/{userId}/posts/{postId}")).isTrue();
+	}
+
+	@Test
+	public void testIsUriTemplateWithVariableAtStart() {
+		assertThat(McpProviderUtils.isUriTemplate("{id}/details")).isTrue();
+	}
+
+	@Test
+	public void testIsUriTemplateWithVariableAtEnd() {
+		assertThat(McpProviderUtils.isUriTemplate("/api/users/{id}")).isTrue();
+	}
+
+	@Test
+	public void testIsUriTemplateWithComplexVariableName() {
+		assertThat(McpProviderUtils.isUriTemplate("/api/{user_id}")).isTrue();
+		assertThat(McpProviderUtils.isUriTemplate("/api/{userId123}")).isTrue();
+	}
+
+	@Test
+	public void testIsUriTemplateWithNoVariables() {
+		assertThat(McpProviderUtils.isUriTemplate("/api/users")).isFalse();
+	}
+
+	@Test
+	public void testIsUriTemplateWithEmptyString() {
+		assertThat(McpProviderUtils.isUriTemplate("")).isFalse();
+	}
+
+	@Test
+	public void testIsUriTemplateWithOnlySlashes() {
+		assertThat(McpProviderUtils.isUriTemplate("/")).isFalse();
+		assertThat(McpProviderUtils.isUriTemplate("//")).isFalse();
+	}
+
+	@Test
+	public void testIsUriTemplateWithIncompleteBraces() {
+		assertThat(McpProviderUtils.isUriTemplate("/api/{id")).isFalse();
+		assertThat(McpProviderUtils.isUriTemplate("/api/id}")).isFalse();
+	}
+
+	@Test
+	public void testIsUriTemplateWithEmptyBraces() {
+		assertThat(McpProviderUtils.isUriTemplate("/api/{}")).isFalse();
+	}
+
+	@Test
+	public void testIsUriTemplateWithNestedPath() {
+		assertThat(McpProviderUtils.isUriTemplate("/api/v1/users/{userId}/posts/{postId}/comments")).isTrue();
+	}
+
+	// Reactive Return Type Predicate Tests
+
+	@Test
+	public void testIsReactiveReturnTypeWithMono() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("monoMethod");
+		assertThat(McpProviderUtils.isReactiveReturnType.test(method)).isTrue();
+	}
+
+	@Test
+	public void testIsReactiveReturnTypeWithFlux() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("fluxMethod");
+		assertThat(McpProviderUtils.isReactiveReturnType.test(method)).isTrue();
+	}
+
+	@Test
+	public void testIsReactiveReturnTypeWithPublisher() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("publisherMethod");
+		assertThat(McpProviderUtils.isReactiveReturnType.test(method)).isTrue();
+	}
+
+	@Test
+	public void testIsReactiveReturnTypeWithNonReactive() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("nonReactiveMethod");
+		assertThat(McpProviderUtils.isReactiveReturnType.test(method)).isFalse();
+	}
+
+	@Test
+	public void testIsReactiveReturnTypeWithVoid() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("voidMethod");
+		assertThat(McpProviderUtils.isReactiveReturnType.test(method)).isFalse();
+	}
+
+	@Test
+	public void testIsReactiveReturnTypeWithList() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("listMethod");
+		assertThat(McpProviderUtils.isReactiveReturnType.test(method)).isFalse();
+	}
+
+	// Non-Reactive Return Type Predicate Tests
+
+	@Test
+	public void testIsNotReactiveReturnTypeWithMono() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("monoMethod");
+		assertThat(McpProviderUtils.isNotReactiveReturnType.test(method)).isFalse();
+	}
+
+	@Test
+	public void testIsNotReactiveReturnTypeWithFlux() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("fluxMethod");
+		assertThat(McpProviderUtils.isNotReactiveReturnType.test(method)).isFalse();
+	}
+
+	@Test
+	public void testIsNotReactiveReturnTypeWithPublisher() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("publisherMethod");
+		assertThat(McpProviderUtils.isNotReactiveReturnType.test(method)).isFalse();
+	}
+
+	@Test
+	public void testIsNotReactiveReturnTypeWithNonReactive() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("nonReactiveMethod");
+		assertThat(McpProviderUtils.isNotReactiveReturnType.test(method)).isTrue();
+	}
+
+	@Test
+	public void testIsNotReactiveReturnTypeWithVoid() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("voidMethod");
+		assertThat(McpProviderUtils.isNotReactiveReturnType.test(method)).isTrue();
+	}
+
+	@Test
+	public void testIsNotReactiveReturnTypeWithList() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("listMethod");
+		assertThat(McpProviderUtils.isNotReactiveReturnType.test(method)).isTrue();
+	}
+
+	// Filter Non-Reactive Return Type Method Tests
+
+	@Test
+	public void testFilterNonReactiveReturnTypeMethodWithReactiveType() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("monoMethod");
+		Predicate<Method> filter = McpProviderUtils.filterNonReactiveReturnTypeMethod();
+		assertThat(filter.test(method)).isTrue();
+	}
+
+	@Test
+	public void testFilterNonReactiveReturnTypeMethodWithNonReactiveType() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("nonReactiveMethod");
+		Predicate<Method> filter = McpProviderUtils.filterNonReactiveReturnTypeMethod();
+		// This should return false and log a warning
+		assertThat(filter.test(method)).isFalse();
+	}
+
+	@Test
+	public void testFilterNonReactiveReturnTypeMethodWithFlux() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("fluxMethod");
+		Predicate<Method> filter = McpProviderUtils.filterNonReactiveReturnTypeMethod();
+		assertThat(filter.test(method)).isTrue();
+	}
+
+	@Test
+	public void testFilterNonReactiveReturnTypeMethodWithPublisher() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("publisherMethod");
+		Predicate<Method> filter = McpProviderUtils.filterNonReactiveReturnTypeMethod();
+		assertThat(filter.test(method)).isTrue();
+	}
+
+	// Filter Reactive Return Type Method Tests
+
+	@Test
+	public void testFilterReactiveReturnTypeMethodWithReactiveType() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("monoMethod");
+		Predicate<Method> filter = McpProviderUtils.filterReactiveReturnTypeMethod();
+		// This should return false and log a warning
+		assertThat(filter.test(method)).isFalse();
+	}
+
+	@Test
+	public void testFilterReactiveReturnTypeMethodWithNonReactiveType() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("nonReactiveMethod");
+		Predicate<Method> filter = McpProviderUtils.filterReactiveReturnTypeMethod();
+		assertThat(filter.test(method)).isTrue();
+	}
+
+	@Test
+	public void testFilterReactiveReturnTypeMethodWithFlux() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("fluxMethod");
+		Predicate<Method> filter = McpProviderUtils.filterReactiveReturnTypeMethod();
+		// This should return false and log a warning
+		assertThat(filter.test(method)).isFalse();
+	}
+
+	@Test
+	public void testFilterReactiveReturnTypeMethodWithPublisher() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("publisherMethod");
+		Predicate<Method> filter = McpProviderUtils.filterReactiveReturnTypeMethod();
+		// This should return false and log a warning
+		assertThat(filter.test(method)).isFalse();
+	}
+
+	@Test
+	public void testFilterReactiveReturnTypeMethodWithVoid() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("voidMethod");
+		Predicate<Method> filter = McpProviderUtils.filterReactiveReturnTypeMethod();
+		assertThat(filter.test(method)).isTrue();
+	}
+
+	// Filter Method With Bidirectional Parameters Tests
+
+	@Test
+	public void testFilterMethodWithBidirectionalParametersWithSyncContext() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("methodWithSyncContext", McpSyncRequestContext.class);
+		Predicate<Method> filter = McpProviderUtils.filterMethodWithBidirectionalParameters();
+		// This should return false and log a warning
+		assertThat(filter.test(method)).isFalse();
+	}
+
+	@Test
+	public void testFilterMethodWithBidirectionalParametersWithAsyncContext() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("methodWithAsyncContext", McpAsyncRequestContext.class);
+		Predicate<Method> filter = McpProviderUtils.filterMethodWithBidirectionalParameters();
+		// This should return false and log a warning
+		assertThat(filter.test(method)).isFalse();
+	}
+
+	@Test
+	public void testFilterMethodWithBidirectionalParametersWithSyncExchange() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("methodWithSyncExchange", McpSyncServerExchange.class);
+		Predicate<Method> filter = McpProviderUtils.filterMethodWithBidirectionalParameters();
+		// This should return false and log a warning
+		assertThat(filter.test(method)).isFalse();
+	}
+
+	@Test
+	public void testFilterMethodWithBidirectionalParametersWithAsyncExchange() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("methodWithAsyncExchange", McpAsyncServerExchange.class);
+		Predicate<Method> filter = McpProviderUtils.filterMethodWithBidirectionalParameters();
+		// This should return false and log a warning
+		assertThat(filter.test(method)).isFalse();
+	}
+
+	@Test
+	public void testFilterMethodWithBidirectionalParametersWithMultipleParams() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("methodWithMultipleParams", String.class,
+				McpSyncRequestContext.class, int.class);
+		Predicate<Method> filter = McpProviderUtils.filterMethodWithBidirectionalParameters();
+		// This should return false because it has a bidirectional parameter
+		assertThat(filter.test(method)).isFalse();
+	}
+
+	@Test
+	public void testFilterMethodWithBidirectionalParametersWithoutBidirectionalParams() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("methodWithoutBidirectionalParams", String.class, int.class);
+		Predicate<Method> filter = McpProviderUtils.filterMethodWithBidirectionalParameters();
+		assertThat(filter.test(method)).isTrue();
+	}
+
+	@Test
+	public void testFilterMethodWithBidirectionalParametersWithNoParams() throws NoSuchMethodException {
+		Method method = TestMethods.class.getMethod("nonReactiveMethod");
+		Predicate<Method> filter = McpProviderUtils.filterMethodWithBidirectionalParameters();
+		assertThat(filter.test(method)).isTrue();
+	}
+
+	// Combined Filter Tests
+
+	@Test
+	public void testCombinedFiltersForStatelessSyncProvider() throws NoSuchMethodException {
+		// Stateless sync providers should filter out:
+		// 1. Methods with reactive return types
+		// 2. Methods with bidirectional parameters
+
+		Method validMethod = TestMethods.class.getMethod("methodWithoutBidirectionalParams", String.class, int.class);
+		Method reactiveMethod = TestMethods.class.getMethod("monoMethod");
+		Method bidirectionalMethod = TestMethods.class.getMethod("methodWithSyncContext", McpSyncRequestContext.class);
+
+		Predicate<Method> reactiveFilter = McpProviderUtils.filterReactiveReturnTypeMethod();
+		Predicate<Method> bidirectionalFilter = McpProviderUtils.filterMethodWithBidirectionalParameters();
+		Predicate<Method> combinedFilter = reactiveFilter.and(bidirectionalFilter);
+
+		assertThat(combinedFilter.test(validMethod)).isTrue();
+		assertThat(combinedFilter.test(reactiveMethod)).isFalse();
+		assertThat(combinedFilter.test(bidirectionalMethod)).isFalse();
+	}
+
+	@Test
+	public void testCombinedFiltersForStatelessAsyncProvider() throws NoSuchMethodException {
+		// Stateless async providers should filter out:
+		// 1. Methods with non-reactive return types
+		// 2. Methods with bidirectional parameters
+
+		Method validMethod = TestMethods.class.getMethod("monoMethod");
+		Method nonReactiveMethod = TestMethods.class.getMethod("nonReactiveMethod");
+		Method bidirectionalMethod = TestMethods.class.getMethod("methodWithAsyncContext",
+				McpAsyncRequestContext.class);
+
+		Predicate<Method> nonReactiveFilter = McpProviderUtils.filterNonReactiveReturnTypeMethod();
+		Predicate<Method> bidirectionalFilter = McpProviderUtils.filterMethodWithBidirectionalParameters();
+		Predicate<Method> combinedFilter = nonReactiveFilter.and(bidirectionalFilter);
+
+		assertThat(combinedFilter.test(validMethod)).isTrue();
+		assertThat(combinedFilter.test(nonReactiveMethod)).isFalse();
+		assertThat(combinedFilter.test(bidirectionalMethod)).isFalse();
+	}
+
+	// Edge Case Tests
+
+	@Test
+	public void testIsUriTemplateWithSpecialCharacters() {
+		assertThat(McpProviderUtils.isUriTemplate("/api/{user-id}")).isTrue();
+		assertThat(McpProviderUtils.isUriTemplate("/api/{user.id}")).isTrue();
+	}
+
+	@Test
+	public void testIsUriTemplateWithQueryParameters() {
+		// Query parameters are not URI template variables
+		assertThat(McpProviderUtils.isUriTemplate("/api/users?id={id}")).isTrue();
+	}
+
+	@Test
+	public void testIsUriTemplateWithFragment() {
+		assertThat(McpProviderUtils.isUriTemplate("/api/users#{id}")).isTrue();
+	}
+
+	@Test
+	public void testIsUriTemplateWithMultipleConsecutiveVariables() {
+		assertThat(McpProviderUtils.isUriTemplate("/{id}{name}")).isTrue();
+	}
+
+	@Test
+	public void testPredicatesAreReusable() throws NoSuchMethodException {
+		// Test that predicates can be reused multiple times
+		Predicate<Method> filter = McpProviderUtils.filterReactiveReturnTypeMethod();
+
+		Method method1 = TestMethods.class.getMethod("nonReactiveMethod");
+		Method method2 = TestMethods.class.getMethod("monoMethod");
+		Method method3 = TestMethods.class.getMethod("listMethod");
+
+		assertThat(filter.test(method1)).isTrue();
+		assertThat(filter.test(method2)).isFalse();
+		assertThat(filter.test(method3)).isTrue();
+	}
+
+}


### PR DESCRIPTION
Major changes:
- Add capability check methods (rootsEnabled, elicitEnabled, sampleEnabled) to both sync and async request contexts
- Replace Optional return types with direct returns and throw IllegalStateException when capabilities not supported
- Change from warning logs to exceptions for unsupported operations in stateless contexts
- Removed stateless context implementations (StatelessAsyncRequestContext, StatelessMcpSyncRequestContext)
- Add bidirectional parameter filtering for stateless providers (tools, resources, prompts, completions)
- Update tests to verify new exception-based error handling
- Updated README

Breaking changes:
- McpSyncRequestContext methods now return direct types instead of Optional<T>
- McpAsyncRequestContext methods now return Mono.error() instead of Mono.empty() for unsupported operations
- Stateless context methods throw IllegalStateException instead of logging warnings

This improves API clarity by making capability checks explicit and error handling more predictable.