### PR TITLE
chore: update project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,23 +56,23 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 
-		<mcp.java.sdk.version>0.14.1</mcp.java.sdk.version>
+		<mcp.java.sdk.version>0.15.0</mcp.java.sdk.version>
 
 		<jsonschema.version>4.38.0</jsonschema.version>
 		<swagger-annotations.version>2.2.36</swagger-annotations.version>
 		
 		<!-- MUST KEEP JACKSON VERSION ALIGNED WITH the mcp-json-jackson2 version -->
-		<jackson-databind.version>2.17.0</jackson-databind.version>
+		<jackson-databind.version>2.19.2</jackson-databind.version>
 
 		<slf4j-api.version>2.0.16</slf4j-api.version>
 		<logback.version>1.5.15</logback.version>
 		
 		<!-- test dependencies -->
-		<assert4j.version>3.26.3</assert4j.version>
+		<assert4j.version>3.27.6</assert4j.version>
 		<junit.version>5.10.2</junit.version>
-		<mockito.version>5.17.0</mockito.version>
+		<mockito.version>5.20.0</mockito.version>
 		<testcontainers.version>1.20.4</testcontainers.version>
-		<byte-buddy.version>1.17.5</byte-buddy.version>
+		<byte-buddy.version>1.17.8</byte-buddy.version>
 
 		<!-- plugin versions -->
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>


### PR DESCRIPTION
- Upgrade mcp-java-sdk from 0.14.1 to 0.15.0
- Upgrade jackson-databind from 2.17.0 to 2.19.2
- Upgrade assert4j from 3.26.3 to 3.27.6
- Upgrade mockito from 5.17.0 to 5.20.0
- Upgrade byte-buddy from 1.17.5 to 1.17.8