### PR TITLE
fix: README.md git repository link for java sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project consists of one module:
 
 The MCP Annotations project enables developers to easily create and register methods for handling MCP operations using simple annotations. It provides a clean, declarative approach to implementing MCP server functionality, reducing boilerplate code and improving maintainability.
 
-This library builds on top of the [MCP Java SDK](https://github.com/modelcontextprotocol/sdk-java) to provide a higher-level, annotation-based programming model for implementing MCP servers and clients.
+This library builds on top of the [MCP Java SDK](https://github.com/modelcontextprotocol/java-sdk) to provide a higher-level, annotation-based programming model for implementing MCP servers and clients.
 
 ## Installation
 


### PR DESCRIPTION
This pull request updates the documentation to reference the correct MCP Java SDK repository link in the `README.md` file.

Documentation correction:

* Updated the MCP Java SDK link in the `README.md` file to point to the correct repository (`modelcontextprotocol/java-sdk` instead of `modelcontextprotocol/sdk-java`).