### PR TITLE
Feat:  add McpToolBody which Annotates tool method parameter which is a business object

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The library automatically filters methods based on the server type and method ch
 - **`@McpResource`** - Annotates methods that provide access to resources
 - **`@McpTool`** - Annotates methods that implement MCP tools with automatic JSON schema generation
   - **`@McpToolParam`** - Annotates tool method parameters with descriptions and requirement specifications
+  - **`@McpToolBody`** - Annotates tool method parameter which is a business object
 
 #### Special Parameters and Annotations
 - **`McpSyncRequestContext`** - Special parameter type for synchronous operations that provides a unified interface for accessing MCP request context, including the original request, server exchange (for stateful operations), transport context (for stateless operations), and convenient methods for logging, progress, sampling, and elicitation. This parameter is automatically injected and excluded from JSON schema generation. **Supported in Complete, Prompt, Resource, and Tool methods.**
@@ -452,10 +453,8 @@ public class CalculatorToolProvider {
                  idempotentHint = true
              ))
     public AreaResult calculateRectangleArea(
-            @McpToolParam(description = "Width of the rectangle", required = true) double width,
-            @McpToolParam(description = "Height of the rectangle", required = true) double height) {
-        
-        double area = width * height;
+            @McpToolBody CalculateAreaRequest toolBody) {
+        double area = toolBody.getWidth() * toolBody.getHeight();
         return new AreaResult(area, "square units");
     }
 
@@ -507,6 +506,29 @@ public class CalculatorToolProvider {
         Map<String, Object> additionalArgs = request.arguments();
         
         return actionResult + " with " + (additionalArgs.size() - 1) + " additional parameters";
+    }
+
+    public static class CalculateAreaRequest {
+        @McpToolParam(description = "Width of the rectangle", required = true)
+        private double width;
+        @McpToolParam(description = "Height of the rectangle", required = true) 
+        private double height;
+
+        public double getWidth() {
+            return width;
+        }
+
+        public void setWidth(double width) {
+            this.width = width;
+        }
+
+        public double getHeight() {
+            return height;
+        }
+
+        public void setHeight(double height) {
+            this.height = height;
+        }
     }
 
     public static class AreaResult {

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpProgress.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpProgress.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
  *
  * <p>
  * Methods annotated with this annotation can be used to consume progress messages from
- * MCP servers. The methods takes a single parameter of type {@code ProgressNotification}
+ * MCP servers. The methods take a single parameter of type {@code ProgressNotification}
  *
  *
  * <p>

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpPrompt.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpPrompt.java
@@ -11,7 +11,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a method as a MCP Prompt.
+ * Marks a method as an MCP Prompt.
  *
  * @author Christian Tzolov
  */

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpToolBody.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/annotation/McpToolBody.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+package org.springaicommunity.mcp.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method parameter as an MCP body.
+ *
+ * @author lemonj
+ */
+@Target({ ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface McpToolBody {
+
+}

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/method/tool/AbstractMcpToolMethodCallback.java
@@ -28,6 +28,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import org.springaicommunity.mcp.annotation.McpMeta;
 import org.springaicommunity.mcp.annotation.McpProgressToken;
 import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolBody;
 import org.springaicommunity.mcp.context.McpAsyncRequestContext;
 import org.springaicommunity.mcp.context.McpRequestContextTypes;
 import org.springaicommunity.mcp.context.McpSyncRequestContext;
@@ -105,6 +106,11 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 			if (parameter.isAnnotationPresent(McpProgressToken.class)) {
 				// Return the progress token from the request
 				return request != null ? request.progressToken() : null;
+			}
+
+			// Check if parameter is annotated with @McpToolBody
+			if (parameter.isAnnotationPresent(McpToolBody.class)) {
+				return buildTypedArgument(toolInputArguments, parameter.getParameterizedType());
 			}
 
 			// Check if parameter is McpMeta type


### PR DESCRIPTION
## design
During the development of MCP tools, when a method requires multiple parameters, using the @McpToolParam annotation may reduce code readability. To address this, inspired by the @RequestBody（org.springframework.web.bind.annotation.RequestBody） annotation in the Spring framework, I have added the @McpToolBody annotation. This allows parameters to be passed as a structured business object, thereby improving code clarity and maintainability.

## example

```java
    // use  @McpToolParam
    @McpTool(name = "calculate-area", 
             description = "Calculate the area of a rectangle")
    public AreaResult calculateRectangleArea(
            @McpToolParam(description = "Width of the rectangle", required = true) double width,
            @McpToolParam(description = "Height of the rectangle", required = true) double height) {
        double area = width * height;
        return new AreaResult(area, "square units");
    }

   // use  @McpToolBody
   @McpTool(name = "calculate-area", 
             description = "Calculate the area of a rectangle")
    public AreaResult calculateRectangleArea(
            @McpToolBody CalculateAreaRequest toolBody) {
        double area = request.getWidth() * request.getHeight();
        return new AreaResult(area, "square units");
    }

    public static class CalculateAreaRequest {
        @McpToolParam(description = "Width of the rectangle", required = true)
        private double width;
        @McpToolParam(description = "Height of the rectangle", required = true) 
        private double height;

        public double getWidth() {
            return width;
        }

        public void setWidth(double width) {
            this.width = width;
        }

        public double getHeight() {
            return height;
        }

        public void setHeight(double height) {
            this.height = height;
        }
    }
```


### changelist
- add  file `McpToolBody`  
- correct the syntax errors in the comments of file  `McpProgress
- correct the syntax errors in the comments of file  `McpPrompt
- add McpToolBody input support in `org.springaicommunity.mcp.method.tool.utils.JsonSchemaGenerator#internalGenerateFromMethodArguments`
-  Add McpToolBody parameter conversion support in  `org.springaicommunity.mcp.method.tool.AbstractMcpToolMethodCallback#buildMethodArguments`
- add McpToolBody example  in readme