### PR TITLE
Fix @McpResource title not propagated to Resource/ResourceTemplate

### DIFF
--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/ResourceAdapter.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/adapter/ResourceAdapter.java
@@ -64,6 +64,7 @@ public class ResourceAdapter {
 		return McpSchema.ResourceTemplate.builder()
 			.uriTemplate(mcpResource.uri())
 			.name(name)
+			.title(mcpResource.title())
 			.description(mcpResource.description())
 			.mimeType(mcpResource.mimeType())
 			.meta(meta)

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncMcpResourceProvider.java
@@ -90,6 +90,7 @@ public class AsyncMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
@@ -97,6 +98,7 @@ public class AsyncMcpResourceProvider {
 					var mcpResource = McpSchema.Resource.builder()
 						.uri(uri)
 						.name(name)
+						.title(title)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)
@@ -143,6 +145,7 @@ public class AsyncMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
@@ -150,6 +153,7 @@ public class AsyncMcpResourceProvider {
 					var mcpResourceTemplate = McpSchema.ResourceTemplate.builder()
 						.uriTemplate(uri)
 						.name(name)
+						.title(title)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProvider.java
@@ -91,6 +91,7 @@ public class AsyncStatelessMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
@@ -98,6 +99,7 @@ public class AsyncStatelessMcpResourceProvider {
 					var mcpResource = McpSchema.Resource.builder()
 						.uri(uri)
 						.name(name)
+						.title(title)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)
@@ -144,6 +146,7 @@ public class AsyncStatelessMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
@@ -151,6 +154,7 @@ public class AsyncStatelessMcpResourceProvider {
 					var mcpResourceTemplate = McpSchema.ResourceTemplate.builder()
 						.uriTemplate(uri)
 						.name(name)
+						.title(title)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncMcpResourceProvider.java
@@ -65,6 +65,7 @@ public class SyncMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
@@ -72,6 +73,7 @@ public class SyncMcpResourceProvider {
 					var mcpResource = McpSchema.Resource.builder()
 						.uri(uri)
 						.name(name)
+						.title(title)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)
@@ -110,6 +112,7 @@ public class SyncMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
@@ -117,6 +120,7 @@ public class SyncMcpResourceProvider {
 					var mcpResourceTemplate = McpSchema.ResourceTemplate.builder()
 						.uriTemplate(uri)
 						.name(name)
+						.title(title)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)

--- a/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProvider.java
+++ b/mcp-annotations/src/main/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProvider.java
@@ -90,6 +90,7 @@ public class SyncStatelessMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
@@ -97,6 +98,7 @@ public class SyncStatelessMcpResourceProvider {
 					var mcpResource = McpSchema.Resource.builder()
 						.uri(uri)
 						.name(name)
+						.title(title)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)
@@ -143,6 +145,7 @@ public class SyncStatelessMcpResourceProvider {
 					}
 
 					var name = getName(mcpResourceMethod, resourceAnnotation);
+					var title = resourceAnnotation.title();
 					var description = resourceAnnotation.description();
 					var mimeType = resourceAnnotation.mimeType();
 					var meta = MetaUtils.getMeta(resourceAnnotation.metaProvider());
@@ -150,6 +153,7 @@ public class SyncStatelessMcpResourceProvider {
 					var mcpResourceTemplate = McpSchema.ResourceTemplate.builder()
 						.uriTemplate(uri)
 						.name(name)
+						.title(title)
 						.description(description)
 						.mimeType(mimeType)
 						.meta(meta)

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/AsyncMcpResourceProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/AsyncMcpResourceProviderTests.java
@@ -462,6 +462,50 @@ public class AsyncMcpResourceProviderTests {
 	}
 
 	@Test
+	void testGetResourceSpecificationsWithTitle() {
+		class TitleResource {
+
+			@McpResource(uri = "title://resource", name = "title-resource", title = "My Resource Title",
+					description = "Resource with title")
+			public Mono<String> titleResource() {
+				return Mono.just("Title resource content");
+			}
+
+		}
+
+		TitleResource resourceObject = new TitleResource();
+		AsyncMcpResourceProvider provider = new AsyncMcpResourceProvider(List.of(resourceObject));
+
+		List<AsyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isEqualTo("My Resource Title");
+		assertThat(resourceSpecs.get(0).resource().name()).isEqualTo("title-resource");
+	}
+
+	@Test
+	void testGetResourceTemplateSpecificationsWithTitle() {
+		class TitleTemplateResource {
+
+			@McpResource(uri = "title://resource/{id}", name = "title-template", title = "My Template Title",
+					description = "Template with title")
+			public Mono<String> titleTemplateResource(String id) {
+				return Mono.just("Template content for: " + id);
+			}
+
+		}
+
+		TitleTemplateResource resourceObject = new TitleTemplateResource();
+		AsyncMcpResourceProvider provider = new AsyncMcpResourceProvider(List.of(resourceObject));
+
+		var resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		assertThat(resourceTemplateSpecs).hasSize(1);
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().title()).isEqualTo("My Template Title");
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().name()).isEqualTo("title-template");
+	}
+
+	@Test
 	void testGetResourceSpecificationsWithSyncMethodReturningMono() {
 		class SyncMethodReturningMono {
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/AsyncStatelessMcpResourceProviderTests.java
@@ -464,6 +464,50 @@ public class AsyncStatelessMcpResourceProviderTests {
 	}
 
 	@Test
+	void testGetResourceSpecificationsWithTitle() {
+		class TitleResource {
+
+			@McpResource(uri = "title://resource", name = "title-resource", title = "My Resource Title",
+					description = "Resource with title")
+			public Mono<String> titleResource() {
+				return Mono.just("Title resource content");
+			}
+
+		}
+
+		TitleResource resourceObject = new TitleResource();
+		AsyncStatelessMcpResourceProvider provider = new AsyncStatelessMcpResourceProvider(List.of(resourceObject));
+
+		List<AsyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isEqualTo("My Resource Title");
+		assertThat(resourceSpecs.get(0).resource().name()).isEqualTo("title-resource");
+	}
+
+	@Test
+	void testGetResourceTemplateSpecificationsWithTitle() {
+		class TitleTemplateResource {
+
+			@McpResource(uri = "title://resource/{id}", name = "title-template", title = "My Template Title",
+					description = "Template with title")
+			public Mono<String> titleTemplateResource(String id) {
+				return Mono.just("Template content for: " + id);
+			}
+
+		}
+
+		TitleTemplateResource resourceObject = new TitleTemplateResource();
+		AsyncStatelessMcpResourceProvider provider = new AsyncStatelessMcpResourceProvider(List.of(resourceObject));
+
+		var resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		assertThat(resourceTemplateSpecs).hasSize(1);
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().title()).isEqualTo("My Template Title");
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().name()).isEqualTo("title-template");
+	}
+
+	@Test
 	void testGetResourceSpecificationsWithSyncMethodReturningMono() {
 		class SyncMethodReturningMono {
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/SyncMcpResourceProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/SyncMcpResourceProviderTests.java
@@ -510,6 +510,50 @@ public class SyncMcpResourceProviderTests {
 	}
 
 	@Test
+	void testGetResourceSpecificationsWithTitle() {
+		class TitleResource {
+
+			@McpResource(uri = "title://resource", name = "title-resource", title = "My Resource Title",
+					description = "Resource with title")
+			public String titleResource() {
+				return "Title resource content";
+			}
+
+		}
+
+		TitleResource resourceObject = new TitleResource();
+		SyncMcpResourceProvider provider = new SyncMcpResourceProvider(List.of(resourceObject));
+
+		List<SyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isEqualTo("My Resource Title");
+		assertThat(resourceSpecs.get(0).resource().name()).isEqualTo("title-resource");
+	}
+
+	@Test
+	void testGetResourceTemplateSpecificationsWithTitle() {
+		class TitleTemplateResource {
+
+			@McpResource(uri = "title://resource/{id}", name = "title-template", title = "My Template Title",
+					description = "Template with title")
+			public String titleTemplateResource(String id) {
+				return "Template content for: " + id;
+			}
+
+		}
+
+		TitleTemplateResource resourceObject = new TitleTemplateResource();
+		SyncMcpResourceProvider provider = new SyncMcpResourceProvider(List.of(resourceObject));
+
+		List<SyncResourceTemplateSpecification> resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		assertThat(resourceTemplateSpecs).hasSize(1);
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().title()).isEqualTo("My Template Title");
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().name()).isEqualTo("title-template");
+	}
+
+	@Test
 	void testGetResourceSpecificationsWithNoParameters() {
 		class NoParameterResource {
 

--- a/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProviderTests.java
+++ b/mcp-annotations/src/test/java/org/springaicommunity/mcp/provider/resource/SyncStatelessMcpResourceProviderTests.java
@@ -427,6 +427,50 @@ public class SyncStatelessMcpResourceProviderTests {
 	}
 
 	@Test
+	void testGetResourceSpecificationsWithTitle() {
+		class TitleResource {
+
+			@McpResource(uri = "title://resource", name = "title-resource", title = "My Resource Title",
+					description = "Resource with title")
+			public String titleResource() {
+				return "Title resource content";
+			}
+
+		}
+
+		TitleResource resourceObject = new TitleResource();
+		SyncStatelessMcpResourceProvider provider = new SyncStatelessMcpResourceProvider(List.of(resourceObject));
+
+		List<SyncResourceSpecification> resourceSpecs = provider.getResourceSpecifications();
+
+		assertThat(resourceSpecs).hasSize(1);
+		assertThat(resourceSpecs.get(0).resource().title()).isEqualTo("My Resource Title");
+		assertThat(resourceSpecs.get(0).resource().name()).isEqualTo("title-resource");
+	}
+
+	@Test
+	void testGetResourceTemplateSpecificationsWithTitle() {
+		class TitleTemplateResource {
+
+			@McpResource(uri = "title://resource/{id}", name = "title-template", title = "My Template Title",
+					description = "Template with title")
+			public String titleTemplateResource(String id) {
+				return "Template content for: " + id;
+			}
+
+		}
+
+		TitleTemplateResource resourceObject = new TitleTemplateResource();
+		SyncStatelessMcpResourceProvider provider = new SyncStatelessMcpResourceProvider(List.of(resourceObject));
+
+		List<SyncResourceTemplateSpecification> resourceTemplateSpecs = provider.getResourceTemplateSpecifications();
+
+		assertThat(resourceTemplateSpecs).hasSize(1);
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().title()).isEqualTo("My Template Title");
+		assertThat(resourceTemplateSpecs.get(0).resourceTemplate().name()).isEqualTo("title-template");
+	}
+
+	@Test
 	void testGetResourceSpecificationsWithRequestParameter() {
 		class RequestParameterResource {
 


### PR DESCRIPTION
## Summary

The `@McpResource` annotation has a `title` attribute, but none of the resource provider classes (`AsyncMcpResourceProvider`, `AsyncStatelessMcpResourceProvider`, `SyncMcpResourceProvider`, `SyncStatelessMcpResourceProvider`) copied it into the `McpSchema.Resource` or `McpSchema.ResourceTemplate` objects they build. Additionally, `ResourceAdapter.asResourceTemplate()` was missing the `.title()` call (while `asResource()` already had it).

For example, given:

```java
@McpResource(uri = "test://resource", name = "test", title = "My Resource Title", description = "A test resource")
public ReadResourceResult readResource() { ... }
```

After building via any resource provider's `getResourceSpecifications()`:
- `resource.title()` was `null` (expected: `"My Resource Title"`)

This PR fixes the issue by reading `resourceAnnotation.title()` and passing it to `.title()` on both `McpSchema.Resource` and `McpSchema.ResourceTemplate` builders in all four provider classes and in `ResourceAdapter.asResourceTemplate()`.